### PR TITLE
chore(http_utils): refactor to use http options

### DIFF
--- a/lib/provider/chromedriver.spec-int.ts
+++ b/lib/provider/chromedriver.spec-int.ts
@@ -19,7 +19,7 @@ describe('chromedriver', () => {
 
     describe('updateBinary', () => {
       beforeEach(() => {
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
         try {
           fs.mkdirSync(tmpDir);
         } catch (err) {}

--- a/lib/provider/chromedriver.ts
+++ b/lib/provider/chromedriver.ts
@@ -45,7 +45,8 @@ export class ChromeDriver {
    * @param version Optional to provide the version number or latest.
    */
   async updateBinary(version?: string): Promise<any> {
-    await updateXml(this.requestUrl, path.resolve(this.outDir, this.cacheFileName));
+    await updateXml(this.requestUrl,
+      { fileName: path.resolve(this.outDir, this.cacheFileName) });
     let versionList = convertXmlToVersionList(
       path.resolve(this.outDir, this.cacheFileName), '.zip',
       versionParser,
@@ -63,7 +64,8 @@ export class ChromeDriver {
     try {
       size = fs.statSync(chromeDriverZip).size;
     } catch (err) {}
-    await requestBinary(chromeDriverUrl, chromeDriverZip, size);
+    await requestBinary(chromeDriverUrl,
+      { fileName: chromeDriverZip, fileSize: size });
 
     // Unzip and rename all the files (a grand total of 1) and set the
     // permissions.

--- a/lib/provider/geckodriver.spec-int.ts
+++ b/lib/provider/geckodriver.spec-int.ts
@@ -14,7 +14,7 @@ describe('geckodriver', () => {
   describe('class GeckoDriver', () => {
     describe('updateBinary', () => {
       beforeEach(() => {
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
         try {
           fs.mkdirSync(tmpDir);
         } catch (err) {}

--- a/lib/provider/geckodriver.ts
+++ b/lib/provider/geckodriver.ts
@@ -38,7 +38,8 @@ export class GeckoDriver {
    * @param version Optional to provide the version number or latest.
    */
   async updateBinary(version?: string): Promise<any> {
-    await updateJson(this.requestUrl, path.resolve(this.outDir, this.cacheFileName),
+    await updateJson(this.requestUrl, 
+      { fileName: path.resolve(this.outDir, this.cacheFileName) },
       this.oauthToken);
     let versionList = convertJsonToVersionList(
       path.resolve(this.outDir, this.cacheFileName));
@@ -55,7 +56,8 @@ export class GeckoDriver {
     try {
       size = fs.statSync(geckoDriverCompressed).size;
     } catch (err) {}
-    await requestBinary(geckoDriverUrl, geckoDriverCompressed, size);
+    await requestBinary(geckoDriverUrl,
+      { fileName: geckoDriverCompressed, fileSize: size });
 
     // Uncompress tarball (for linux and mac) or unzip the file for Windows.
     // Rename all the files (a grand total of 1) and set the permissions.

--- a/lib/provider/iedriver.spec-int.ts
+++ b/lib/provider/iedriver.spec-int.ts
@@ -17,7 +17,7 @@ describe('iedriver', () => {
     let origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
 
     beforeEach(() => {
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
       try {
         fs.mkdirSync(tmpDir);
       } catch (err) {}

--- a/lib/provider/iedriver.ts
+++ b/lib/provider/iedriver.ts
@@ -34,7 +34,8 @@ export class IEDriver {
    * @param version Optional to provide the version number or latest.
    */
   async updateBinary(version?: string): Promise<any> {
-    await updateXml(this.requestUrl, path.resolve(this.outDir, this.cacheFileName));
+    await updateXml(this.requestUrl,
+      { fileName: path.resolve(this.outDir, this.cacheFileName) });
     let versionList = convertXmlToVersionList(
       path.resolve(this.outDir, this.cacheFileName), '.zip',
       versionParser,
@@ -52,7 +53,8 @@ export class IEDriver {
     try {
       size = fs.statSync(chromeDriverZip).size;
     } catch (err) {}
-    await requestBinary(chromeDriverUrl, chromeDriverZip, size);
+    await requestBinary(chromeDriverUrl,
+      { fileName: chromeDriverZip, fileSize: size });
 
     // Unzip and rename all the files (a grand total of 1) and set the
     // permissions.

--- a/lib/provider/selenium_server.spec-int.ts
+++ b/lib/provider/selenium_server.spec-int.ts
@@ -17,7 +17,7 @@ describe('selenium_server', () => {
     let origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
 
     beforeEach(() => {
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
       try {
         fs.mkdirSync(tmpDir);
       } catch (err) {}

--- a/lib/provider/selenium_server.ts
+++ b/lib/provider/selenium_server.ts
@@ -26,7 +26,8 @@ export class SeleniumServer {
    * @param version Optional to provide the version number or latest.
    */
   async updateBinary(version?: string): Promise<any> {
-    await updateXml(this.requestUrl, path.resolve(this.outDir, this.cacheFileName));
+    await updateXml(this.requestUrl,
+      { fileName: path.resolve(this.outDir, this.cacheFileName) });
     let versionList = convertXmlToVersionList(
       path.resolve(this.outDir, this.cacheFileName), 'selenium-server-standalone',
       versionParser,
@@ -44,7 +45,8 @@ export class SeleniumServer {
     try {
       size = fs.statSync(seleniumServerJar).size;
     } catch (err) {}
-    await requestBinary(seleniumServerUrl, seleniumServerJar, size);
+    await requestBinary(seleniumServerUrl,
+      { fileName: seleniumServerJar, fileSize: size });
     generateConfigFile(this.outDir,
       path.resolve(this.outDir, this.configFileName),
       matchBinaries(), seleniumServerJar);

--- a/lib/provider/utils/cloud_storage_xml.spec-int.ts
+++ b/lib/provider/utils/cloud_storage_xml.spec-int.ts
@@ -31,7 +31,7 @@ describe('cloud_storage_xml', () => {
   let origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
 
   beforeAll((done) => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
     proc = spawnProcess('node', ['dist/spec/server/http_server.js']);
     console.log('http-server: ' + proc.pid);
     setTimeout(done, 3000);
@@ -68,7 +68,7 @@ describe('cloud_storage_xml', () => {
         fs.statSync(fileName);
         done.fail('file should not exist.');
       } catch (err) {
-        updateXml(xmlUrl, fileName).then(xmlContent => {
+        updateXml(xmlUrl, { fileName: fileName }).then(xmlContent => {
           expect(fs.statSync(fileName).size).toBeGreaterThan(0);
           expect(xmlContent['ListBucketResult']['Contents'][0]['Key'][0])
             .toBe('2.0/foobar.zip');
@@ -89,7 +89,7 @@ describe('cloud_storage_xml', () => {
       spyOn(fs, 'statSync').and.returnValue({size: 1000, mtime: mtime});
 
       try {
-        updateXml(xmlUrl, fileName).then(xmlContent => {
+        updateXml(xmlUrl, { fileName: fileName }).then(xmlContent => {
           expect(fsStatSync(fileName).size).toBeGreaterThan(0);
           expect(fsStatSync(fileName).size).not.toBe(1000);
           expect(fsStatSync(fileName).mtime.getMilliseconds())
@@ -115,7 +115,7 @@ describe('cloud_storage_xml', () => {
       spyOn(fs, 'statSync').and.returnValue({size: 1000, mtime: mtime});
 
       try {
-        updateXml(xmlUrl, fileName).then(xmlContent => {
+        updateXml(xmlUrl, { fileName: fileName }).then(xmlContent => {
           expect(fsStatSync(fileName).size).toBe(initialStats.size);
           expect(fsStatSync(fileName).mtime.getMilliseconds())
             .toBe(initialStats.mtime.getMilliseconds());

--- a/lib/provider/utils/cloud_storage_xml.ts
+++ b/lib/provider/utils/cloud_storage_xml.ts
@@ -3,32 +3,32 @@ import * as path from 'path';
 import * as semver from 'semver';
 import { convertXml2js, readXml } from './file_utils';
 import { isExpired } from './file_utils';
-import { requestBody, JsonObject } from './http_utils';
+import { HttpOptions, JsonObject, requestBody } from './http_utils';
 import { VersionList } from './version_list';
 
 /**
  * Read the xml file from cache. If the cache time has been exceeded or the
  * file does not exist, make an http request and write it to the file.
  * @param xmlUrl The xml url.
- * @param fileName The xml filename.
+ * @param httpOptions The http options for the request.
+ * @returns A promise for the xml translated to a json object
  */
 export async function updateXml(
     xmlUrl: string,
-    fileName: string): Promise<JsonObject> {
+    httpOptions: HttpOptions): Promise<JsonObject> {
 
-  if (isExpired(fileName)) {
-    let contents = await requestBody(xmlUrl, null, fileName);
-    let dir = path.dirname(fileName);
+  if (isExpired(httpOptions.fileName)) {
+    let contents = await requestBody(xmlUrl, httpOptions);
+    let dir = path.dirname(httpOptions.fileName);
     try {
       fs.mkdirSync(dir);
     } catch (err) {}
-    fs.writeFileSync(fileName, contents);
+    fs.writeFileSync(httpOptions.fileName, contents);
     return convertXml2js(contents);
   } else {
-    return readXml(fileName);
+    return readXml(httpOptions.fileName);
   }
 }
-
 
 /**
  * Returns a list of versions and the partial url paths.

--- a/lib/provider/utils/file_utils.spec-int.ts
+++ b/lib/provider/utils/file_utils.spec-int.ts
@@ -137,7 +137,6 @@ describe('file_utils', () => {
       generateConfigFile(tmpDir, tmpFile, fileBinaryPathRegex, lastBinary);
 
       let contents = fs.readFileSync(tmpFile).toString();
-      console.log(contents);
       let jsonContents = JSON.parse(contents);
       expect(jsonContents['last']).toBe(lastBinary);
       expect(jsonContents['all'].length).toBe(2);

--- a/lib/provider/utils/github_json.spec-int.ts
+++ b/lib/provider/utils/github_json.spec-int.ts
@@ -7,6 +7,17 @@ const fileName = path.resolve('spec/support/files/gecko.json');
 describe('github_json', () => {
 
   describe('requestRateLimit', () => {
+    let origTimeout: number;
+
+    beforeAll(() => {
+      origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000;
+    });
+
+    afterAll(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
+    });
+
     it('should get rate limit assuming quota exists', async(done) => {
       if (!await checkConnectivity('rate limit test')) {
         done();

--- a/lib/provider/utils/github_json.spec-unit.ts
+++ b/lib/provider/utils/github_json.spec-unit.ts
@@ -1,10 +1,12 @@
 import { hasQuota, RequestMethod } from './github_json';
+import { HttpOptions } from './http_utils';
 
 describe('github_json', () => {
   describe('hasQuota', () => {
     it('should return true when there is quota', async() => {
       let requestMethod: RequestMethod = function(
-          jsonUrl: string, fileName?: string,
+          jsonUrl: string,
+          httpOptions: HttpOptions,
           oauthToken?: string): Promise<string|null> {
         return Promise.resolve('{ "resources": { "core": { "remaining": 1 } } }');
       };
@@ -13,7 +15,9 @@ describe('github_json', () => {
     });
 
     it('should return false when there is no quota', async() => {
-      let requestMethod = function(jsonUrl: string, fileName?: string,
+      let requestMethod: RequestMethod = function(
+          jsonUrl: string,
+          httpOptions: HttpOptions,
           oauthToken?: string): Promise<string|null> {
         return Promise.resolve('{ "resources": { "core": { "remaining": 0 } } }');
       };
@@ -22,7 +26,9 @@ describe('github_json', () => {
     });
 
     it('should return false when something wrong happened', async() => {
-      let requestMethod = function(jsonUrl: string, fileName?: string,
+      let requestMethod: RequestMethod = function(
+          jsonUrl: string,
+          httpOptions: HttpOptions,
           oauthToken?: string): Promise<string|null> {
         return Promise.resolve('');
       };

--- a/lib/provider/utils/github_json.ts
+++ b/lib/provider/utils/github_json.ts
@@ -1,11 +1,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { isExpired, readJson } from './file_utils';
-import { JsonObject, requestBody } from './http_utils';
+import { HttpOptions, JsonObject, requestBody } from './http_utils';
 import { VersionList } from './version_list';
 
 export interface RequestMethod {
-  (jsonUrl: string, fileName?: string, oauthToken?: string):
+  (jsonUrl: string, httpOptions: HttpOptions, oauthToken?: string):
     Promise<string|null>;
 }
 
@@ -13,33 +13,33 @@ export interface RequestMethod {
  * Read the json file from cache. If the cache time has been exceeded or the
  * file does not exist, make an http request and write it to the file.
  * @param jsonUrl The json url.
- * @param fileName The json filename.
+ * @param httpOptions The http options for the request.
  * @param oauthToken An optional oauth token.
  */
 export async function updateJson(
     jsonUrl: string,
-    fileName: string,
+    httpOptions: HttpOptions,
     oauthToken?: string): Promise<JsonObject|null> {
 
-  if (isExpired(fileName)) {
+  if (isExpired(httpOptions.fileName)) {
     let contents: string;
 
     // Create the folder to store the cache.
-    let dir = path.dirname(fileName);
+    let dir = path.dirname(httpOptions.fileName);
     try {
       fs.mkdirSync(dir);
     } catch (err) {}
 
     // Check the rate limit and if there is quota for this request.
     if (await hasQuota(oauthToken)) {
-      contents = await requestGitHubJson(jsonUrl, fileName, oauthToken);
-      fs.writeFileSync(fileName, contents);
+      contents = await requestGitHubJson(jsonUrl, httpOptions, oauthToken);
+      fs.writeFileSync(httpOptions.fileName, contents);
       return JSON.parse(contents);
     } else {
       return null;
     }
   } else {
-    return readJson(fileName);
+    return readJson(httpOptions.fileName);
   }
 }
 
@@ -55,32 +55,34 @@ export function requestRateLimit(
     requestMethod?: RequestMethod): Promise<string|null> {
   let rateLimitUrl = 'https://api.github.com/rate_limit';
   if (requestMethod) {
-    return requestMethod(rateLimitUrl, null, oauthToken);
+    return requestMethod(rateLimitUrl, {}, oauthToken);
   } else {
-    return requestGitHubJson(rateLimitUrl, null, oauthToken);
+    return requestGitHubJson(rateLimitUrl, {}, oauthToken);
   }
 }
 
 /**
  * Request the GitHub json url and log the curl.
  * @param jsonUrl The json url.
- * @param fileName An optional json filename.
+ * @param httpOptions The http options for the request.
  * @param oauthToken An optional oauth token.
  * @returns A promised string of the response body.
  */
 export function requestGitHubJson(
     jsonUrl: string,
-    fileName?: string,
+    httpOptions: HttpOptions,
     oauthToken?: string): Promise<string|null> {
-  let headers: {[key:string]: string|number} = {};
-  headers['User-Agent'] = 'angular/webdriver-manager';
+  if (!httpOptions.headers) {
+    httpOptions.headers = {};
+  }
+  httpOptions.headers['User-Agent'] = 'angular/webdriver-manager';
   if (oauthToken) {
-    headers['Authorization'] = 'token ' + oauthToken;
+    httpOptions.headers['Authorization'] = 'token ' + oauthToken;
   } else if (process.env['GITHUB_TOKEN'] || process.env['github_token']) {
     let token = process.env['GITHUB_TOKEN'] || process.env['github_token'];
-    headers['Authorization'] = 'token ' + token;
+    httpOptions.headers['Authorization'] = 'token ' + token;
   }
-  return requestBody(jsonUrl, headers, fileName);
+  return requestBody(jsonUrl, httpOptions);
 }
 
 /**

--- a/lib/provider/utils/http_utils.spec-int.ts
+++ b/lib/provider/utils/http_utils.spec-int.ts
@@ -46,7 +46,8 @@ describe('binary_utils', () => {
   describe('requestBinary', () => {
     it('should download the file if no file exists or ' +
         'the content lenght is different', (done) => {
-      requestBinary(binaryUrl, fileName, 0).then((result) => {
+      requestBinary(binaryUrl, { fileName: fileName, fileSize: 0 })
+          .then((result) => {
         expect(result).toBeTruthy();
         expect(fs.statSync(fileName).size).toBe(barZipSize);
         done();
@@ -56,7 +57,8 @@ describe('binary_utils', () => {
     });
 
     it('should not download the file if the file exists', (done) => {
-      requestBinary(binaryUrl, fileName, barZipSize).then((result) => {
+      requestBinary(binaryUrl, { fileName: fileName, fileSize: barZipSize })
+          .then((result) => {
         expect(result).toBeFalsy();
         expect(fs.statSync(fileName).size).toBe(barZipSize);
         done();
@@ -68,14 +70,14 @@ describe('binary_utils', () => {
 
   describe('requestBody', () => {
     it('should download a json object file', async() => {
-      let foo  = await requestBody(fooJsonUrl);
+      let foo  = await requestBody(fooJsonUrl, {});
       let fooJson = JSON.parse(foo);
       expect(fooJson["foo"]).toBe("abc");
       expect(fooJson["bar"]).toBe(123);
     });
 
     it('should download a json array file', async() => {
-      let foo  = await requestBody(fooArrayUrl);
+      let foo  = await requestBody(fooArrayUrl, {});
       let fooJson = JSON.parse(foo);
       expect(fooJson.length).toBe(3);
       expect(fooJson[0]['foo']).toBe('abc');
@@ -84,7 +86,7 @@ describe('binary_utils', () => {
     });
   
     it('should get the xml file', async() => {
-      let text = await requestBody(fooXmlUrl);
+      let text = await requestBody(fooXmlUrl, {});
       expect(text.length).toBeGreaterThan(0);
     });
   });

--- a/lib/provider/utils/http_utils.spec-proxy.ts
+++ b/lib/provider/utils/http_utils.spec-proxy.ts
@@ -51,7 +51,8 @@ describe('binary_utils', () => {
   describe('requestBinary', () => {
     it('should download the file if no file exists or ' +
         'the content lenght is different', (done) => {
-      requestBinary(binaryUrl, fileName, 0, headers).then((result) => {
+      let options = { fileName: fileName, fileSize: 0, headers: headers };
+      requestBinary(binaryUrl, options).then((result) => {
         expect(result).toBeTruthy();
         expect(fs.statSync(fileName).size).toBe(barZipSize);
         done();
@@ -61,7 +62,8 @@ describe('binary_utils', () => {
     });
 
     it('should not download the file if the file exists', (done) => {
-      requestBinary(binaryUrl, fileName, barZipSize, headers).then((result) => {
+      let options = { fileName: fileName, fileSize: barZipSize, headers: headers };
+      requestBinary(binaryUrl, options).then((result) => {
         expect(result).toBeFalsy();
         expect(fs.statSync(fileName).size).toBe(barZipSize);
         done();
@@ -73,14 +75,14 @@ describe('binary_utils', () => {
 
   describe('requestBody', () => {
     it('should download a json object file', async() => {
-      let foo  = await requestBody(fooJsonUrl, headers);
+      let foo = await requestBody(fooJsonUrl, { headers: headers });
       let fooJson = JSON.parse(foo);
       expect(fooJson["foo"]).toBe("abc");
       expect(fooJson["bar"]).toBe(123);
     });
 
     it('should download a json array file', async() => {
-      let foo  = await requestBody(fooArrayUrl, headers);
+      let foo  = await requestBody(fooArrayUrl, { headers: headers });
       let fooJson = JSON.parse(foo);
       expect(fooJson.length).toBe(3);
       expect(fooJson[0]['foo']).toBe('abc');
@@ -89,7 +91,7 @@ describe('binary_utils', () => {
     });
   
     it('should get the xml file', async() => {
-      let text = await requestBody(fooXmlUrl, headers);
+      let text = await requestBody(fooXmlUrl, { headers: headers });
       expect(text.length).toBeGreaterThan(0);
     });
   });

--- a/lib/provider/utils/http_utils.spec-unit.ts
+++ b/lib/provider/utils/http_utils.spec-unit.ts
@@ -3,14 +3,13 @@ import {
   initOptions,
   optionsProxy,
   optionsSSL,
-  resolveProxy,
-  RequestOptionsValue } from './http_utils';
+  resolveProxy } from './http_utils';
 
 describe('http utils', () => {
   describe('initOptions', () => {
     it('should create options', () => {
       let requestUrl = 'http://foobar.com';
-      let options = initOptions(requestUrl);
+      let options = initOptions(requestUrl, {});
       expect(options['url']).toBe(requestUrl);
       expect(options['timeout']).toBe(240000);
       expect(options['proxy']).toBeUndefined();
@@ -21,7 +20,7 @@ describe('http utils', () => {
     it('should create options with a proxy', () => {
       let requestUrl = 'http://foobar.com';
       let proxy = 'http://baz.com';
-      let options = initOptions(requestUrl, undefined, proxy);
+      let options = initOptions(requestUrl, { proxy: proxy });
       expect(options['url']).toBe(requestUrl);
       expect(options['timeout']).toBe(240000);
       expect(options['proxy']).toBe(proxy);
@@ -31,7 +30,7 @@ describe('http utils', () => {
 
     it('should create options with SSL', () => {
       let requestUrl = 'http://foobar.com';
-      let options = initOptions(requestUrl, true, undefined);
+      let options = initOptions(requestUrl, { ignoreSSL: true });
       expect(options['url']).toBe(requestUrl);
       expect(options['timeout']).toBe(240000);
       expect(options['proxy']).toBeUndefined();
@@ -42,7 +41,7 @@ describe('http utils', () => {
     it('should create options with SSL and proxy', () => {
       let requestUrl = 'http://foobar.com';
       let proxy = 'http://baz.com';
-      let options = initOptions(requestUrl, true, proxy);
+      let options = initOptions(requestUrl, { proxy: proxy });
       expect(options['url']).toBe(requestUrl);
       expect(options['timeout']).toBe(240000);
       expect(options['proxy']).toBe(proxy);
@@ -53,7 +52,7 @@ describe('http utils', () => {
 
   describe('optionsSSL', () => {
     it('should set strictSSL and rejectUnauthorized', () => {
-      let options: RequestOptionsValue = { url: 'http://foobar.com' };
+      let options: any = { url: 'http://foobar.com' };
       let ignoreSSL = true;
       options = optionsSSL(options, ignoreSSL);
       expect(options['strictSSL']).toBeFalsy();
@@ -61,7 +60,7 @@ describe('http utils', () => {
     });
   
     it('should set not set strictSSL and rejectUnauthorized', () => {
-      let options: RequestOptionsValue = { url: 'http://foobar.com' };
+      let options: any = { url: 'http://foobar.com' };
       let ignoreSSL = false;
       options = optionsSSL(options, ignoreSSL);
       expect(options['strictSSL']).toBeUndefined();
@@ -72,7 +71,7 @@ describe('http utils', () => {
   describe('optionsProxy', () => {
     it('should set the proxy', () => {
       let requestUrl = 'http://foobar.com';
-      let options: RequestOptionsValue = { url: requestUrl };
+      let options: any = { url: requestUrl };
       let proxy = 'http://baz.com';
       options = optionsProxy(options, requestUrl, proxy);
       expect(options['proxy']).toBe(proxy);
@@ -80,7 +79,7 @@ describe('http utils', () => {
 
     it('should not set the proxy when the proxy is undefined', () => {
       let requestUrl = 'http://foobar.com';
-      let options: RequestOptionsValue = { url: requestUrl };
+      let options: any = { url: requestUrl };
       options = optionsProxy(options, requestUrl, undefined);
       expect(options['proxy']).toBeUndefined();
     });
@@ -149,7 +148,7 @@ describe('http utils', () => {
   });
 
   describe('addHeader', () => {
-    let options: RequestOptionsValue;
+    let options: any;
     beforeEach(() => {
       options = {
         url: 'http://foo.bar'

--- a/lib/provider/utils/http_utils.ts
+++ b/lib/provider/utils/http_utils.ts
@@ -3,61 +3,87 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as request from 'request';
 
-export interface RequestOptionsValue extends request.OptionsWithUrl {
+/**
+ * The request options that extend the request. This is not exported
+ * in preference to build an HttpOptions object with extra metadata
+ * and the http_utils methods will help build this object.
+ */
+interface RequestOptionsValue extends request.OptionsWithUrl {
   proxy?: string;
   ignoreSSL?: boolean;
 }
 
+/**
+ * A json object interface
+ */
 export interface JsonObject {
   [key:string]: any;
 }
 
 /**
+ * The http option interface to build the request.
+ */
+export interface HttpOptions {
+  fileName?: string;
+  fileSize?: number;
+  headers?: { [key:string]: string|number };
+  ignoreSSL?: boolean;
+  proxy?: string;
+}
+
+/**
  * Initialize the request options.
- * @param url 
- * @param opt_ignoreSSL 
- * @param opt_proxy 
+ * @param requestUrl The url to navigate to.
+ * @param httpOptions The http options for the request.
+ * @returns The request options.
  */
 export function initOptions(
-    url: string,
-    opt_ignoreSSL?: boolean,
-    opt_proxy?: string): RequestOptionsValue {
+    requestUrl: string,
+    httpOptions: HttpOptions): RequestOptionsValue {
 
   let options: RequestOptionsValue = {
-    url: url,
+    url: requestUrl,
     // default Linux can be anywhere from 20-120 seconds
     // increasing this arbitrarily to 4 minutes
     timeout: 240000
   };
-  options = optionsSSL(options, opt_ignoreSSL);
-  options = optionsProxy(options, url, opt_proxy);
+  options = optionsSSL(options, httpOptions.ignoreSSL);
+  options = optionsProxy(options, requestUrl, httpOptions.proxy);
   return options;
 }
 
 /**
  * Set ignore SSL option.
  * @param options The HTTP options
- * @param opt_ignoreSSL The ignore SSL option.
+ * @param ignoreSSL The ignore ssl option.
+ * @returns The request options.
  */
 export function optionsSSL(
     options: RequestOptionsValue,
-    opt_ignoreSSL: boolean): RequestOptionsValue {
+    ignoreSSL: boolean): RequestOptionsValue {
 
-  if (opt_ignoreSSL) {
+  if (ignoreSSL) {
     // console.log('ignoring SSL certificate');
-    options.strictSSL = !opt_ignoreSSL;
-    (options as any).rejectUnauthorized = !opt_ignoreSSL;
+    options.strictSSL = !ignoreSSL;
+    (options as any).rejectUnauthorized = !ignoreSSL;
   }
   return options;
 }
 
+/**
+ * 
+ * @param options The HTTP options
+ * @param requestUrl The url to navigate to.
+ * @param proxy: The proxy url.
+ * @returns The request options.
+ */
 export function optionsProxy(
     options: RequestOptionsValue,
     requestUrl: string,
-    opt_proxy: string): RequestOptionsValue {
+    proxy: string): RequestOptionsValue {
 
-  if (opt_proxy) {
-    options.proxy = resolveProxy(requestUrl, opt_proxy);
+  if (proxy) {
+    options.proxy = resolveProxy(requestUrl, proxy);
     if (url.parse(requestUrl).protocol === 'https:') {
       options.url = requestUrl.replace('https:', 'http:');
     }
@@ -67,16 +93,16 @@ export function optionsProxy(
 
 /**
  * Resolves proxy based on values set.
- * @param requestUrl The url to download the file.
- * @param opt_proxy The proxy to connect to to download files.
- * @return Either undefined or the proxy.
+ * @param requestUrl The url to navigate to.
+ * @param proxy: The proxy url.
+ * @returns Either undefined or the proxy.
  */
 export function resolveProxy(
     requestUrl: string,
-    opt_proxy: string): string {
+    proxy: string): string {
 
-  if (opt_proxy) {
-    return opt_proxy;
+  if (proxy) {
+    return proxy;
   } else {
     let protocol = url.parse(requestUrl).protocol;
     let hostname = url.parse(requestUrl).hostname;
@@ -112,11 +138,12 @@ export function resolveProxy(
 /**
  * Builds a curl command for logging purposes.
  * @param requestOptions The request options.
- * @param fileName The file name path.
+ * @param httpOptions The http options for the request.
  * @returns The curl command.
  */
-export function curlCommand(requestOptions: RequestOptionsValue,
-    fileName?: string) {
+export function curlCommand(
+    requestOptions: RequestOptionsValue,
+    httpOptions: HttpOptions) {
   let curl = `${requestOptions.url}`;
   if (requestOptions.proxy) {
     let pathUrl = url.parse(requestOptions.url.toString()).path;
@@ -133,8 +160,8 @@ export function curlCommand(requestOptions: RequestOptionsValue,
   if (requestOptions.ignoreSSL) {
     curl = `-k ${curl}`;
   }
-  if (fileName) {
-    curl = `-o ${fileName} ${curl}`;
+  if (httpOptions.fileName) {
+    curl = `-o ${httpOptions.fileName} ${curl}`;
   }
   return `curl ${curl}`;
 }
@@ -146,7 +173,9 @@ export function curlCommand(requestOptions: RequestOptionsValue,
  * @param value The value of the header.
  * @returns The modified options object.
  */
-export function addHeader(options: RequestOptionsValue, name: string,
+export function addHeader(
+    options: RequestOptionsValue,
+    name: string,
     value: string|number): RequestOptionsValue {
   if (!options.headers) {
     options.headers = {};
@@ -158,21 +187,14 @@ export function addHeader(options: RequestOptionsValue, name: string,
 /**
  * The request to download the binary.
  * @param binaryUrl The download url for the binary.
- * @param fileName The file path to save the binary.
- * @param fileSize The file size used for validation.
- * @param headers Optional headers object of key-values.
+ * @param httpOptions The http options for the request.
  */
-export function requestBinary(binaryUrl: string,
-    fileName: string, fileSize: number,
-    headers?: {[key:string]: string|number}): Promise<boolean> {
-  let options = initOptions(binaryUrl);
-  if (headers) {
-    for(let key of Object.keys(headers)) {
-      addHeader(options, key, headers[key]);
-    }
-  }
+export function requestBinary(
+    binaryUrl: string,
+    httpOptions: HttpOptions): Promise<boolean> {
+  let options = initOptions(binaryUrl, httpOptions);
   options.followRedirect = true;
-  console.log(curlCommand(options, fileName));
+  console.log(curlCommand(options, httpOptions));
 
   return new Promise<boolean>((resolve, reject) => {
     let req = request(options);
@@ -182,24 +204,24 @@ export function requestBinary(binaryUrl: string,
         // Check to see if the size is the same.
         // If the file size is the same, do not download and stop here.
         contentLength = +response.headers['content-length'];
-        if (contentLength === fileSize) {
+        if (contentLength === httpOptions.fileSize) {
           response.destroy();
           resolve(false);
         } else {
           // Only pipe if the headers are different length.
-          let dir = path.dirname(fileName);
+          let dir = path.dirname(httpOptions.fileName);
           try {
             fs.mkdirSync(dir);
           } catch (err) {}
-          let file = fs.createWriteStream(fileName);
+          let file = fs.createWriteStream(httpOptions.fileName);
           req.pipe(file);
           file.on('close', () => {
-            fs.stat(fileName, (error, stats) => {
+            fs.stat(httpOptions.fileName, (error, stats) => {
               if (error) {
                 reject(error);
               }
               if (stats.size != contentLength) {
-                fs.unlinkSync(fileName);
+                fs.unlinkSync(httpOptions.fileName);
                 reject(error);
               }
               resolve(true);
@@ -220,20 +242,20 @@ export function requestBinary(binaryUrl: string,
  * Request the body from the url and log the curl.
  * @param requestUrl The request url.
  * @param headers Optional headers object of key-values.
- * @param fileName An optional json filename.
+ * @param opt_ignoreSSL The ignore SSL option.
+ * @param opt_proxy The proxy to connect to to download files.
  * @returns A promise string of the response body.
  */
 export function requestBody(
     requestUrl: string,
-    headers?: {[key:string]: string|number},
-    fileName?: string,): Promise<string> {
-  let options = initOptions(requestUrl);
-  if (headers) {
-    for(let key of Object.keys(headers)) {
-      addHeader(options, key, headers[key]);
+    httpOptions: HttpOptions): Promise<string> {
+  let options = initOptions(requestUrl, httpOptions);
+  if (httpOptions.headers) {
+    for(let key of Object.keys(httpOptions.headers)) {
+      addHeader(options, key, httpOptions.headers[key]);
     }
   }
-  console.log(curlCommand(options, fileName));
+  console.log(curlCommand(options, httpOptions));
 
   return new Promise((resolve, reject) => {
     let req = request(options);

--- a/spec/support/helpers/test_utils.ts
+++ b/spec/support/helpers/test_utils.ts
@@ -22,7 +22,7 @@ export function spawnProcess(task: string, opt_arg?: string[], opt_io?: string) 
  * If the request results in an error, return false.
  */
 export function checkConnectivity(testName: string): Promise<boolean> {
-  return requestBody('https://github.com').then(() => {
+  return requestBody('https://github.com', {}).then(() => {
     return true;
   }).catch(() => {
     console.warn('[WARN] no connectivity. skipping test ' + testName)


### PR DESCRIPTION
- instead of passing variables one at a time that are typical for most
methods, use HttpOptions to capture the variables.