### PR TITLE
chore(proxy): add proxy test for chromedriver

### DIFF
--- a/lib/provider/chromedriver.spec-proxy.ts
+++ b/lib/provider/chromedriver.spec-proxy.ts
@@ -1,0 +1,67 @@
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as rimraf from 'rimraf';
+import {
+  ChromeDriver,
+  semanticVersionParser,
+  versionParser
+} from './chromedriver';
+import { convertXmlToVersionList } from './utils/cloud_storage_xml';
+import { getVersion } from './utils/version_list';
+import { proxyBaseUrl } from '../../spec/server/env';
+import { spawnProcess } from '../../spec/support/helpers/test_utils';
+import { checkConnectivity } from '../../spec/support/helpers/test_utils';
+
+describe('chromedriver', () => {
+  let tmpDir = path.resolve(os.tmpdir(), 'test');
+
+  describe('class ChromeDriver', () => {
+    let origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    let proxyProc: childProcess.ChildProcess;
+
+    describe('updateBinary', () => {
+      beforeEach((done) => {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+        proxyProc = spawnProcess('node', ['dist/spec/server/proxy_server.js']);
+        console.log('proxy-server: ' + proxyProc.pid);
+        setTimeout(done, 3000);
+        try {
+          fs.mkdirSync(tmpDir);
+        } catch (err) {}
+      });
+    
+      afterEach((done) => {
+        spawnProcess('kill', ['-TERM', proxyProc.pid.toString()]);
+        setTimeout(done, 5000);
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
+        try {
+          rimraf.sync(tmpDir);
+        } catch (err) {}
+      });
+
+      it('should download the binary using a proxy', async(done) => {
+        if (!await checkConnectivity('update binary for mac test')) {
+          done();
+        }
+        let chromeDriver = new ChromeDriver({
+          ignoreSSL: true, osType: 'Darwin', osArch: 'x64', outDir: tmpDir,
+          proxy: proxyBaseUrl });
+        await chromeDriver.updateBinary();
+        let configFile = path.resolve(tmpDir, 'chromedriver.config.json');
+        let xmlFile = path.resolve(tmpDir, 'chromedriver.xml');
+        expect(fs.statSync(configFile).size).toBeTruthy();
+        expect(fs.statSync(xmlFile).size).toBeTruthy();
+
+        let versionList = convertXmlToVersionList(xmlFile, '.zip', 
+          versionParser, semanticVersionParser);
+        let versionObj = getVersion(versionList, 'mac');
+        let executableFile = path.resolve(tmpDir,
+          'chromedriver_' + versionObj.version);
+        expect(fs.statSync(executableFile).size).toBeTruthy();
+        done();
+      });
+    });
+  });
+});

--- a/lib/provider/provider.ts
+++ b/lib/provider/provider.ts
@@ -1,0 +1,38 @@
+import * as path from 'path';
+
+// Change the output directory for all providers.
+export const OUT_DIR = path.resolve('.');
+
+/**
+ * The provider updateBinary interface implemented by all providers.
+ */
+export interface Provider {  
+  updateBinary: (version?: string) => Promise<any>;
+}
+
+/**
+ * The provider configuration is passed to the Provider and can override
+ * the default behavior of the provider.
+ */
+export interface ProviderConfig {
+  // The request url to get the list of binaries available to download.
+  requestUrl?: string;
+  // The location of the output directory where to store the cache file,
+  // the config file and the binaries.
+  outDir?: string;
+  // The cache file name is just the file name and not the full path.
+  // The file contains the body returned from the request url.
+  cacheFileName?: string;
+  // The config file name is just the file name and not the full path.
+  // The file contains a json object of the list of all downloaded 
+  // binaries and the last downloaded binary.
+  configFileName?: string;
+  // The os type of this system.
+  osType?: string;
+  // The os architecture of this system.
+  osArch?: string;
+  // The proxy requests must go through (optional).
+  proxy?: string;
+  // Set the requests to ignore SSL (optional).
+  ignoreSSL?: boolean;
+}

--- a/lib/provider/utils/http_utils.spec-unit.ts
+++ b/lib/provider/utils/http_utils.spec-unit.ts
@@ -10,7 +10,7 @@ describe('http utils', () => {
   describe('initOptions', () => {
     it('should create options', () => {
       let requestUrl = 'http://foobar.com';
-      let options = initOptions(requestUrl);
+      let options = initOptions(requestUrl, {});
       expect(options['url']).toBe(requestUrl);
       expect(options['timeout']).toBe(240000);
       expect(options['proxy']).toBeUndefined();
@@ -21,7 +21,7 @@ describe('http utils', () => {
     it('should create options with a proxy', () => {
       let requestUrl = 'http://foobar.com';
       let proxy = 'http://baz.com';
-      let options = initOptions(requestUrl, undefined, proxy);
+      let options = initOptions(requestUrl, { proxy });
       expect(options['url']).toBe(requestUrl);
       expect(options['timeout']).toBe(240000);
       expect(options['proxy']).toBe(proxy);
@@ -31,7 +31,7 @@ describe('http utils', () => {
 
     it('should create options with SSL', () => {
       let requestUrl = 'http://foobar.com';
-      let options = initOptions(requestUrl, true, undefined);
+      let options = initOptions(requestUrl, { ignoreSSL: true });
       expect(options['url']).toBe(requestUrl);
       expect(options['timeout']).toBe(240000);
       expect(options['proxy']).toBeUndefined();
@@ -42,7 +42,7 @@ describe('http utils', () => {
     it('should create options with SSL and proxy', () => {
       let requestUrl = 'http://foobar.com';
       let proxy = 'http://baz.com';
-      let options = initOptions(requestUrl, true, proxy);
+      let options = initOptions(requestUrl, { ignoreSSL: true, proxy });
       expect(options['url']).toBe(requestUrl);
       expect(options['timeout']).toBe(240000);
       expect(options['proxy']).toBe(proxy);

--- a/spec/server/proxy_server.ts
+++ b/spec/server/proxy_server.ts
@@ -6,6 +6,9 @@ const proxy = http.createServer((request, response) => {
   let hostHeader = request.headers['host'];
   console.log('request made to proxy: ' + request.url + ', ' +
     'target: ' + hostHeader);
+  if (!hostHeader.startsWith('http://')) {
+    hostHeader = 'http://' + hostHeader;
+  }
   httpProxy
     .createProxyServer({target: hostHeader})
     .web(request, response);


### PR DESCRIPTION
- Test makes request to the proxy for chromedriver cache and for the
binary. Check to see that the files exist.
- Add provider class interface and configuration interface to be used
by other providers.