### PR TITLE
chore(proxy): add proxy test for geckodriver

### DIFF
--- a/lib/provider/chromedriver.spec-int.ts
+++ b/lib/provider/chromedriver.spec-int.ts
@@ -36,9 +36,8 @@ describe('chromedriver', () => {
         if (!await checkConnectivity('update binary for mac test')) {
           done();
         }
-        let chromedriver = new ChromeDriver();
-        chromedriver.outDir = tmpDir;
-        chromedriver.osType = 'Darwin';
+        let chromedriver = new ChromeDriver(
+          { outDir: tmpDir, osType: 'Darwin' });
         await chromedriver.updateBinary();
 
         let configFile = path.resolve(tmpDir, 'chromedriver.config.json');

--- a/lib/provider/chromedriver.ts
+++ b/lib/provider/chromedriver.ts
@@ -28,13 +28,14 @@ export const CHROME_VERSION: Flag = {
 };
 
 export class ChromeDriver implements Provider {
-  requestUrl = 'https://chromedriver.storage.googleapis.com/';
-  outDir = OUT_DIR;
   cacheFileName = 'chromedriver.xml';
   configFileName = 'chromedriver.config.json';
+  ignoreSSL: boolean = false;
   osType = os.type();
   osArch = os.arch();
+  outDir = OUT_DIR;
   proxy: string = null;
+  requestUrl = 'https://chromedriver.storage.googleapis.com/';
 
   constructor(providerConfig?: ProviderConfig) {
     if (providerConfig) {
@@ -44,6 +45,7 @@ export class ChromeDriver implements Provider {
       if (providerConfig.configFileName) {
         this.configFileName = providerConfig.configFileName;
       }
+      this.ignoreSSL = providerConfig.ignoreSSL;
       if (providerConfig.osArch) {
         this.osArch = providerConfig.osArch;
       }
@@ -70,6 +72,7 @@ export class ChromeDriver implements Provider {
   async updateBinary(version?: string): Promise<any> {
     await updateXml(this.requestUrl, { 
       fileName: path.resolve(this.outDir, this.cacheFileName),
+      ignoreSSL: this.ignoreSSL,
       proxy: this.proxy });
 
     let versionList = convertXmlToVersionList(
@@ -90,7 +93,8 @@ export class ChromeDriver implements Provider {
       fileSize = fs.statSync(chromeDriverZip).size;
     } catch (err) {}
     await requestBinary(chromeDriverUrl,
-      { fileName: chromeDriverZip, fileSize, proxy: this.proxy });
+      { fileName: chromeDriverZip, fileSize, ignoreSSL: this.ignoreSSL,
+        proxy: this.proxy });
 
     // Unzip and rename all the files (a grand total of 1) and set the
     // permissions.

--- a/lib/provider/geckodriver.spec-int.ts
+++ b/lib/provider/geckodriver.spec-int.ts
@@ -31,9 +31,8 @@ describe('geckodriver', () => {
         if (!await checkConnectivity('update binary for mac test')) {
           done();
         }
-        let geckodriver = new GeckoDriver();
-        geckodriver.outDir = tmpDir;
-        geckodriver.osType = 'Darwin';
+        let geckodriver = new GeckoDriver(
+          { outDir: tmpDir, osType: 'Darwin' });
         await geckodriver.updateBinary();
 
         let configFile = path.resolve(tmpDir, 'geckodriver.config.json');

--- a/lib/provider/geckodriver.spec-proxy.ts
+++ b/lib/provider/geckodriver.spec-proxy.ts
@@ -1,0 +1,64 @@
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as rimraf from 'rimraf';
+import {
+  GeckoDriver
+} from './geckodriver';
+import { proxyBaseUrl } from '../../spec/server/env';
+import { spawnProcess } from '../../spec/support/helpers/test_utils';
+import { checkConnectivity } from '../../spec/support/helpers/test_utils';
+import { convertJsonToVersionList } from './utils/github_json';
+import { getVersion } from './utils/version_list';
+
+describe('geckodriver', () => {
+  let tmpDir = path.resolve(os.tmpdir(), 'test');
+
+  describe('class GeckoDriver', () => {
+    let origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    let proxyProc: childProcess.ChildProcess;
+
+    describe('updateBinary', () => {
+      beforeEach((done) => {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+        proxyProc = spawnProcess('node', ['dist/spec/server/proxy_server.js']);
+        console.log('proxy-server: ' + proxyProc.pid);
+        setTimeout(done, 3000);
+        try {
+          fs.mkdirSync(tmpDir);
+        } catch (err) {}
+      });
+    
+      afterEach((done) => {
+        spawnProcess('kill', ['-TERM', proxyProc.pid.toString()]);
+        setTimeout(done, 5000);
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
+        try {
+          rimraf.sync(tmpDir);
+        } catch (err) {}
+      });
+
+      it('should download the binary using a proxy', async(done) => {
+        if (!await checkConnectivity('update binary for mac test')) {
+          done();
+        }
+        let geckoDriver = new GeckoDriver({
+          outDir: tmpDir, osType: 'Darwin', proxy: proxyBaseUrl });
+        await geckoDriver.updateBinary();
+
+        let configFile = path.resolve(tmpDir, 'geckodriver.config.json');
+        let jsonFile = path.resolve(tmpDir, 'geckodriver.json');
+        expect(fs.statSync(configFile).size).toBeTruthy();
+        expect(fs.statSync(jsonFile).size).toBeTruthy();
+
+        let versionList = convertJsonToVersionList(jsonFile);
+        let versionObj = getVersion(versionList, 'macos');
+        let executableFile = path.resolve(tmpDir,
+          'geckodriver_' + versionObj.version);
+        expect(fs.statSync(executableFile).size).toBeTruthy();
+        done();
+      });
+    });
+  });
+});

--- a/spec/server/proxy_server.ts
+++ b/spec/server/proxy_server.ts
@@ -6,12 +6,22 @@ const proxy = http.createServer((request, response) => {
   let hostHeader = request.headers['host'];
   console.log('request made to proxy: ' + request.url + ', ' +
     'target: ' + hostHeader);
-  if (!hostHeader.startsWith('http://')) {
-    hostHeader = 'http://' + hostHeader;
+  if (hostHeader.startsWith('http://') || hostHeader.startsWith('127.0.0.1')) {
+    if (!hostHeader.startsWith('http://')) {
+      hostHeader = 'http://' + hostHeader;
+    }
+    httpProxy
+      .createProxyServer({target: hostHeader})
+      .web(request, response);
+
+  } else {
+    if (!hostHeader.startsWith('https://')) {
+      hostHeader = 'https://' + hostHeader;
+    }
+    httpProxy
+      .createProxyServer({target: hostHeader})
+      .web(request, response);
   }
-  httpProxy
-    .createProxyServer({target: hostHeader})
-    .web(request, response);
 });
 
 proxy.listen(env.proxyPort);


### PR DESCRIPTION
- Test makes request to the proxy for chromedriver cache and for the
binary. Checks to see that the files exist.
- Fix header logging for curl commands
- Update request binary to no longer follow redirects. Instead we will
handle the redirects ourselves.
- Update tests to use the provider configuration interface for the
constructor.