### PR TITLE
chore(selenium): start the selenium server

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -1,5 +1,7 @@
 # Environment variables
 
+**`JAVA_HOME`** - If the java home variable is set as an environment variable, use it when starting the selenium server. The java executable is assumed to be found in `JAVA_HOME/bin/java`.
+
 **`NO_PROXY`** - If the no proxy environment variable exists and matches the host name, to ignore the resolve proxy.
 
 **`HTTPS_PROXY`** - If the https proxy environment variable exists and the url protocol is https, use this proxy.

--- a/lib/provider/chromedriver.ts
+++ b/lib/provider/chromedriver.ts
@@ -9,6 +9,7 @@ import {
 } from './provider';
 import {
   changeFilePermissions,
+  getBinaryPathFromConfig,
   renameFileWithVersion,
   unzipFile,
   zipFileList,
@@ -70,7 +71,7 @@ export class ChromeDriver implements Provider {
    * @param version Optional to provide the version number or latest.
    */
   async updateBinary(version?: string): Promise<any> {
-    await updateXml(this.requestUrl, { 
+    await updateXml(this.requestUrl, {
       fileName: path.resolve(this.outDir, this.cacheFileName),
       ignoreSSL: this.ignoreSSL,
       proxy: this.proxy });
@@ -111,6 +112,15 @@ export class ChromeDriver implements Provider {
     return Promise.resolve();
   }
 
+  /**
+   * Gets the Chromedriver binary file path.
+   * @param version Optional to provide the version number or latest.
+   */
+  getBinaryPath(version?: string): string {
+    let configFilePath = path.resolve(this.outDir, this.configFileName);
+    return getBinaryPathFromConfig(configFilePath, version);
+  }
+
   // TODO(cnishina): A list of chromedriver versions downloaded
 
   // TODO(cnishina): Remove files downloaded
@@ -121,7 +131,7 @@ export class ChromeDriver implements Provider {
  * with composing the download link.
  * @param ostype The operating stystem type.
  * @param osarch The chip architecture.
- * @returns The download name associated with composing the download link. 
+ * @returns The download name associated with composing the download link.
  */
 export function osHelper(ostype: string, osarch: string): string {
   if (ostype === 'Darwin') {

--- a/lib/provider/selenium_server.spec-unit.ts
+++ b/lib/provider/selenium_server.spec-unit.ts
@@ -1,4 +1,5 @@
-import { semanticVersionParser, versionParser } from './selenium_server';
+import { semanticVersionParser, versionParser, SeleniumServer } from './selenium_server';
+import * as fs from 'fs';
 
 describe('selenium_server', () => {
   describe('verisonParser', () => {
@@ -22,6 +23,37 @@ describe('selenium_server', () => {
       version = semanticVersionParser(
         '10.1/selenium-server-standalone-10.1.200-beta.jar');
       expect(version).toBe('10.1.200');
+    });
+  });
+
+  describe('getCmdStartServer', () => {
+    let configBinaries = `{
+      "last": "path/to/selenium-server-3.0.jar",
+      "all": ["path/to/selenium-server-1.0.jar",
+              "path/to/selenium-server-2.0.jar",
+              "path/to/selenium-server-3.0.jar"
+      ]
+    }`;
+    let javaArgs = '-role node ' +
+      '-servlet org.openqa.grid.web.servlet.LifecycleServlet ' +
+      '-registerCycle 0 -port 4444'
+    it('should use a selenium server with no options', () => {
+      spyOn(fs, 'readFileSync').and.returnValue(configBinaries);
+      let seleniumServer = new SeleniumServer();
+      expect(seleniumServer.getCmdStartServer(null))
+        .toContain('java -jar path/to/selenium-server-3.0.jar ' + javaArgs);
+      expect(seleniumServer.getCmdStartServer({}))
+        .toContain('java -jar path/to/selenium-server-3.0.jar ' + javaArgs);
+    });
+
+    it('should use a selenium server with options', () => {
+      spyOn(fs, 'readFileSync').and.returnValue(configBinaries);
+      let seleniumServer = new SeleniumServer();
+      let cmd = seleniumServer.getCmdStartServer(
+        {'-Dwebdriver.chrome.driver': 'path/to/chromedriver'});
+      expect(cmd).toContain(
+        'java -Dwebdriver.chrome.driver=path/to/chromedriver ' +
+        '-jar path/to/selenium-server-3.0.jar ' + javaArgs);
     });
   });
 });

--- a/lib/provider/utils/file_utils.spec-unit.ts
+++ b/lib/provider/utils/file_utils.spec-unit.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import {
   convertXml2js,
+  getBinaryPathFromConfig,
   isExpired,
   getMatchingFiles,
   readJson,
@@ -139,6 +140,26 @@ describe('file_utils', () => {
       let matchedFiles = getMatchingFiles('/path/to', fileBinaryPathRegex);
       expect(matchedFiles[0]).toContain('foo_12.2');
       expect(matchedFiles[1]).toContain('foo_12.4');
+    });
+  });
+
+  describe('getBinaryPathFromConfig', () => {
+    let configBinaries = `{
+      "last": "foo-1.0",
+      "all": ["foo-1.0", "bar-1.1", "baz-1.2"]
+    }`;   
+    it('should find the latest download', () => {
+      spyOn(fs, 'readFileSync').and.returnValue(configBinaries);
+      let last = getBinaryPathFromConfig('path-does-not-exist');
+      expect(last).toBe('foo-1.0');
+    });
+
+    it('should find the download from a version', () => {
+      spyOn(fs, 'readFileSync').and.returnValue(configBinaries);
+      expect(getBinaryPathFromConfig('path-does-not-exist', '1.0'))
+        .toBe('foo-1.0');
+        expect(getBinaryPathFromConfig('path-does-not-exist', '1.2'))
+        .toBe('baz-1.2');
     });
   });
 });

--- a/lib/provider/utils/file_utils.ts
+++ b/lib/provider/utils/file_utils.ts
@@ -208,3 +208,28 @@ export function getMatchingFiles(
   }
   return matchingFiles;
 }
+
+/**
+ * Get the binary path from the configuration file. The configuration file
+ * should be formatted as { 'last': string, 'all': string[] }. In the 'all'
+ * array, we should match the 'version'. The version does not necessarily have
+ * to be a valid semantic version.
+ * @param cacheFilePath The cache file path.
+ * @param version An optional version that is not necessarily semver.
+ */
+export function getBinaryPathFromConfig(
+    cacheFilePath: string,
+    version?: string): string|null {
+  let cacheJson = JSON.parse(fs.readFileSync(cacheFilePath).toString());
+  let binaryPath = null;
+  if (!version) {
+    binaryPath = cacheJson['last'];
+  } else {
+    for (let cachePath of cacheJson['all']) {
+      if (cachePath.match(version)) {
+        binaryPath = cachePath;
+      }
+    }
+  }
+  return binaryPath;
+}

--- a/lib/provider/utils/version_list.ts
+++ b/lib/provider/utils/version_list.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as semver from 'semver';
 
 /**

--- a/lib/start.ts
+++ b/lib/start.ts
@@ -1,0 +1,27 @@
+import { ChromeDriver } from './provider/chromedriver';
+import { SeleniumServer } from './provider/selenium_server';
+
+let chromedriver = new ChromeDriver();
+let seleniumServer = new SeleniumServer();
+
+export function update(): Promise<any> {
+  let promises = [];
+  promises.push(chromedriver.updateBinary());
+  promises.push(seleniumServer.updateBinary());
+
+  return Promise.all(promises);
+}
+
+
+export function start(): Promise<any> {
+  let opts = {
+    '-Dwebdriver.chrome.driver': chromedriver.getBinaryPath()
+  }
+  return seleniumServer.startServer(opts);
+}
+
+update().then(() => {
+  start().then(() => {
+    console.log('indefinitely wait');
+  });
+});


### PR DESCRIPTION
- Add api to stop the server.
- When the SIGINT signal is sent, kill the selenium server pid.
- Add a start.ts to demo starting the selenium server.
- Update environment variable documentation.
- Read the path to the binary from the configuration file.

closes #7