### PR TITLE
fix(selenium): selenium server logs

### DIFF
--- a/lib/cmds/start.ts
+++ b/lib/cmds/start.ts
@@ -1,5 +1,5 @@
 import { Options } from './options';
-import { constructAllProviders } from './utils';
+import { constructProviders } from './utils';
 import { SeleniumServer } from '../provider/selenium_server';
 
 /**
@@ -8,7 +8,7 @@ import { SeleniumServer } from '../provider/selenium_server';
  * @param argv The argv from yargs.
  */
 export function handler(argv: any) {
-  let options = constructAllProviders(argv);
+  let options = constructProviders(argv);
   process.stdin.resume();
   process.on('SIGINT', () => {
     let seleniumServer = options.server.binary as SeleniumServer;

--- a/lib/provider/selenium_server.spec-unit.ts
+++ b/lib/provider/selenium_server.spec-unit.ts
@@ -46,9 +46,9 @@ describe('selenium_server', () => {
       it('should use a selenium server with no options', () => {
         spyOn(fs, 'readFileSync').and.returnValue(configBinaries);
         let seleniumServer = new SeleniumServer();
-        expect(seleniumServer.getCmdStartServer(null))
+        expect(seleniumServer.getCmdStartServer(null).join(' '))
           .toContain('-jar path/to/selenium-server-3.0.jar ' + javaArgs);
-        expect(seleniumServer.getCmdStartServer({}))
+        expect(seleniumServer.getCmdStartServer({}).join(' '))
           .toContain('-jar path/to/selenium-server-3.0.jar ' + javaArgs);
       });
 
@@ -57,7 +57,7 @@ describe('selenium_server', () => {
         let seleniumServer = new SeleniumServer();
         let cmd = seleniumServer.getCmdStartServer(
           {'-Dwebdriver.chrome.driver': 'path/to/chromedriver'});
-        expect(cmd).toContain(
+        expect(cmd.join(' ')).toContain(
           '-Dwebdriver.chrome.driver=path/to/chromedriver ' +
           '-jar path/to/selenium-server-3.0.jar ' + javaArgs);
       });


### PR DESCRIPTION
Use spawn since the log is streamed to console. When using exec, it waits for the command to finish before running a callback to console log.

closes #25 
