### PR TITLE
chore(detach): start the server in detach as role = node

### DIFF
--- a/lib/cli/index.ts
+++ b/lib/cli/index.ts
@@ -16,6 +16,14 @@ const chromeLogsOption: yargs.Options = {
   describe: 'File path to chrome logs.',
   type: 'string'
 };
+const DETACH = 'detach';
+const detachOption: yargs.Options = {
+  describe: 'Once the selenium server is up and running, return ' +
+    'control to the parent process and continue running the server ' +
+    'in the background.',
+  default: false,
+  type: 'boolean'
+};
 const EDGE = 'edge';
 const edgeOption: yargs.Options = {
   describe: 'Use an installed Microsoft edge driver. Usually installed: ' +
@@ -108,6 +116,7 @@ yargs
       return yargs
         .option(CHROME, chromeOption)
         .option(CHROME_LOGS, chromeLogsOption)
+        .option(DETACH, detachOption)
         .option(EDGE, edgeOption)
         .option(GECKO,  geckoOption)
         .option(IEDRIVER, ieOption)

--- a/lib/cmds/options.ts
+++ b/lib/cmds/options.ts
@@ -29,6 +29,8 @@ export interface Options {
     chrome_logs?: string,
     // The full path to the edge driver server
     edge?: string
+    // Detach the server and return the process to the parent.
+    runAsDetach?: boolean
   },
   // The proxy url (must include protocol with url)
   proxy?: string,

--- a/lib/cmds/utils.ts
+++ b/lib/cmds/utils.ts
@@ -42,7 +42,8 @@ export function constructAllProviders(argv: yargs.Arguments): Options {
       name: 'selenium',
       binary: new SeleniumServer(providerConfig),
       version: versionsStandalone,
-      runAsNode: argv.standalone_node
+      runAsNode: argv.standalone_node,
+      runAsDetach: argv.detach
     },
     ignoreSSL: argv.ignore_ssl,
     outDir: argv.out_dir,
@@ -105,6 +106,7 @@ export function constructProviders(argv: yargs.Arguments): Options {
     options.server.runAsNode = argv.standalone_node;
     options.server.chrome_logs = argv.chrome_logs;
     options.server.edge = argv.edge;
+    options.server.runAsDetach = argv.detach;
   }
   return options;
 }


### PR DESCRIPTION
- Start the server as role = node so it can be shutdown with a GET
request.
- Simplifications - set an arbitrary timeout for 2 seconds after
spawning the child process and 500 ms after unreffing the child process.

closes #46