### PR TITLE
chore(logging): isolate the logging level for this module

### DIFF
--- a/lib/cmds/clean.spec-e2e.ts
+++ b/lib/cmds/clean.spec-e2e.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as os from 'os';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
@@ -7,6 +7,7 @@ import * as rimraf from 'rimraf';
 import {clean} from './clean';
 import {constructAllProviders} from './utils';
 
+const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
 
 describe('using the cli', () => {

--- a/lib/cmds/clean.spec-int.ts
+++ b/lib/cmds/clean.spec-int.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as os from 'os';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
@@ -8,7 +8,9 @@ import * as yargs from 'yargs';
 import {clean} from './clean';
 import {constructAllProviders} from './utils';
 
+const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
+
 const tmpDir = path.resolve(os.tmpdir(), 'test');
 const argv: yargs.Arguments = {
   _: ['foobar'],

--- a/lib/cmds/clean.ts
+++ b/lib/cmds/clean.ts
@@ -1,7 +1,9 @@
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as yargs from 'yargs';
 import {Options} from './options';
 import {constructAllProviders} from './utils';
+
+const log = loglevel.getLogger('webdriver-manager');
 
 /**
  * Handles removing files that were downloaded and logs the files.

--- a/lib/cmds/cmds.spec-e2e.ts
+++ b/lib/cmds/cmds.spec-e2e.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as os from 'os';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
@@ -11,6 +11,7 @@ import {status} from './status';
 import {update} from './update';
 import {constructAllProviders, constructProviders,} from './utils';
 
+const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
 
 describe('using the cli', () => {

--- a/lib/cmds/shutdown.ts
+++ b/lib/cmds/shutdown.ts
@@ -1,8 +1,10 @@
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as yargs from 'yargs';
 
 import {SeleniumServer} from '../provider/selenium_server';
 import {Options} from './options';
+
+const log = loglevel.getLogger('webdriver-manager');
 
 /**
  * Handles making the get request to stop the selenium server standalone if the

--- a/lib/cmds/start.ts
+++ b/lib/cmds/start.ts
@@ -1,11 +1,12 @@
-import * as childProcess from 'child_process';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as path from 'path';
 import * as yargs from 'yargs';
 
 import {SeleniumServer} from '../provider/selenium_server';
 import {Options} from './options';
 import {constructProviders} from './utils';
+
+const log = loglevel.getLogger('webdriver-manager');
 
 /**
  * Starts the selenium server standalone with browser drivers. Also handles

--- a/lib/cmds/start_stop.spec-int.ts
+++ b/lib/cmds/start_stop.spec-int.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as http from 'http';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as os from 'os';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
@@ -12,6 +12,7 @@ import {shutdown} from './shutdown';
 import {start} from './start';
 import {update} from './update';
 
+const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
 const tmpDir = path.resolve(os.tmpdir(), 'test');
 const selenium = new SeleniumServer({outDir: tmpDir});

--- a/lib/cmds/status.spec-e2e.ts
+++ b/lib/cmds/status.spec-e2e.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as os from 'os';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
@@ -7,6 +7,7 @@ import * as rimraf from 'rimraf';
 import {status} from './status';
 import {constructAllProviders} from './utils';
 
+const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
 
 describe('using the cli', () => {

--- a/lib/cmds/status.spec-int.ts
+++ b/lib/cmds/status.spec-int.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as os from 'os';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
@@ -8,7 +8,9 @@ import * as yargs from 'yargs';
 import {status} from './status';
 import {constructAllProviders} from './utils';
 
+const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
+
 const tmpDir = path.resolve(os.tmpdir(), 'test');
 const argv: yargs.Arguments = {
   _: ['foobar'],

--- a/lib/cmds/status.ts
+++ b/lib/cmds/status.ts
@@ -1,7 +1,9 @@
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as yargs from 'yargs';
 import {Options} from './options';
 import {constructAllProviders} from './utils';
+
+const log = loglevel.getLogger('webdriver-manager');
 
 /**
  * Displays which versions of providers that have been downloaded.

--- a/lib/cmds/update.spec-int.ts
+++ b/lib/cmds/update.spec-int.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as os from 'os';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
@@ -11,7 +11,9 @@ import {SeleniumServer} from '../provider/selenium_server';
 import {Options} from './options';
 import {update} from './update';
 
+const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
+
 const tmpDir = path.resolve(os.tmpdir(), 'test');
 
 describe('update cmd', () => {

--- a/lib/cmds/update.ts
+++ b/lib/cmds/update.ts
@@ -1,7 +1,9 @@
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as yargs from 'yargs';
 import {Options} from './options';
 import {constructProviders} from './utils';
+
+const log = loglevel.getLogger('webdriver-manager');
 
 /**
  * Updates / downloads the providers binaries.

--- a/lib/provider/appium.ts
+++ b/lib/provider/appium.ts
@@ -1,12 +1,14 @@
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
 import * as semver from 'semver';
 
 import {ProviderConfig, ProviderInterface} from './provider';
 import {requestBody} from './utils/http_utils';
+
+const log = loglevel.getLogger('webdriver-manager');
 
 export class Appium implements ProviderInterface {
   ignoreSSL: boolean;

--- a/lib/provider/chromedriver.spec-proxy.ts
+++ b/lib/provider/chromedriver.spec-proxy.ts
@@ -1,6 +1,6 @@
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as os from 'os';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
@@ -12,6 +12,7 @@ import {ChromeDriver, semanticVersionParser, versionParser} from './chromedriver
 import {convertXmlToVersionList} from './utils/cloud_storage_xml';
 import {getVersion} from './utils/version_list';
 
+const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
 
 describe('chromedriver', () => {

--- a/lib/provider/geckodriver.spec-proxy.ts
+++ b/lib/provider/geckodriver.spec-proxy.ts
@@ -1,6 +1,6 @@
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as os from 'os';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
@@ -12,6 +12,7 @@ import {GeckoDriver} from './geckodriver';
 import {convertJsonToVersionList} from './utils/github_json';
 import {getVersion} from './utils/version_list';
 
+const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
 
 describe('geckodriver', () => {

--- a/lib/provider/selenium_server.spec-unit.ts
+++ b/lib/provider/selenium_server.spec-unit.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import {SeleniumServer, semanticVersionParser, versionParser,} from './selenium_server';
 
-
 describe('selenium_server', () => {
   describe('verisonParser', () => {
     it('should generate a semantic version', () => {

--- a/lib/provider/selenium_server.ts
+++ b/lib/provider/selenium_server.ts
@@ -1,6 +1,6 @@
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as os from 'os';
 import * as path from 'path';
 import * as request from 'request';
@@ -10,6 +10,8 @@ import {convertXmlToVersionList, updateXml} from './utils/cloud_storage_xml';
 import {generateConfigFile, getBinaryPathFromConfig, removeFiles,} from './utils/file_utils';
 import {curlCommand, initOptions, requestBinary} from './utils/http_utils';
 import {getVersion} from './utils/version_list';
+
+const log = loglevel.getLogger('webdriver-manager');
 
 export class SeleniumServer implements ProviderInterface {
   cacheFileName = 'selenium-server.xml';

--- a/lib/provider/utils/cloud_storage_xml.spec-int.ts
+++ b/lib/provider/utils/cloud_storage_xml.spec-int.ts
@@ -1,14 +1,14 @@
 
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as os from 'os';
 import * as path from 'path';
-
 import {httpBaseUrl} from '../../../spec/server/env';
 import {spawnProcess} from '../../../spec/support/helpers/test_utils';
 import {convertXmlToVersionList, updateXml} from './cloud_storage_xml';
 
+const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
 
 function chromedriverVersionParser(key: string): string {

--- a/lib/provider/utils/file_utils.spec-int.ts
+++ b/lib/provider/utils/file_utils.spec-int.ts
@@ -1,10 +1,11 @@
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as os from 'os';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
 import {generateConfigFile, removeFiles, tarFileList, uncompressTarball, unzipFile, zipFileList} from './file_utils';
 
+const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
 
 const tarballFile = path.resolve('spec/support/files/bar.tar.gz');

--- a/lib/provider/utils/github_json.ts
+++ b/lib/provider/utils/github_json.ts
@@ -1,10 +1,12 @@
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as path from 'path';
 
 import {isExpired, readJson} from './file_utils';
 import {HttpOptions, JsonObject, requestBody} from './http_utils';
 import {VersionList} from './version_list';
+
+const log = loglevel.getLogger('webdriver-manager');
 
 export interface RequestMethod {
   (jsonUrl: string, httpOptions: HttpOptions,

--- a/lib/provider/utils/http_utils.spec-int.ts
+++ b/lib/provider/utils/http_utils.spec-int.ts
@@ -1,6 +1,6 @@
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -8,6 +8,7 @@ import {httpBaseUrl} from '../../../spec/server/env';
 import {spawnProcess} from '../../../spec/support/helpers/test_utils';
 import {requestBinary, requestBody} from './http_utils';
 
+const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
 
 const tmpDir = path.resolve(os.tmpdir(), 'test');

--- a/lib/provider/utils/http_utils.spec-proxy.ts
+++ b/lib/provider/utils/http_utils.spec-proxy.ts
@@ -1,6 +1,6 @@
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -9,6 +9,7 @@ import {spawnProcess} from '../../../spec/support/helpers/test_utils';
 
 import {requestBinary, requestBody} from './http_utils';
 
+const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
 
 const tmpDir = path.resolve(os.tmpdir(), 'test');

--- a/lib/provider/utils/http_utils.ts
+++ b/lib/provider/utils/http_utils.ts
@@ -1,8 +1,10 @@
 import * as fs from 'fs';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import * as path from 'path';
 import * as request from 'request';
 import * as url from 'url';
+
+const log = loglevel.getLogger('webdriver-manager');
 
 /**
  * The request options that extend the request. This is not exported

--- a/spec/support/helpers/test_utils.ts
+++ b/spec/support/helpers/test_utils.ts
@@ -1,6 +1,8 @@
 import * as childProcess from 'child_process';
-import * as log from 'loglevel';
+import * as loglevel from 'loglevel';
 import {requestBody} from '../../../lib/provider/utils/http_utils';
+
+const log = loglevel.getLogger('webdriver-manager-test');
 
 /**
  * A command line to run. Example 'npm start', the task='npm' and the


### PR DESCRIPTION
- Set the loglevel for this project with loglevel using the
logger name 'webdriver-manager'.
- Set the loglevel for the tests as 'webdriver-manager-test'.

closes #78