### PR TITLE
chore(options): simplify options object

### DIFF
--- a/lib/cmds/clean.spec-e2e.ts
+++ b/lib/cmds/clean.spec-e2e.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as rimraf from 'rimraf';
 
 import {clean} from './clean';
-import {constructAllProviders} from './utils';
+import {convertArgs2AllOptions} from './utils';
 
 const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
@@ -26,7 +26,7 @@ describe('using the cli', () => {
         out_dir: tmpDir,
         '$0': 'bin\\webdriver-manager'
       };
-      const options = constructAllProviders(argv);
+      const options = convertArgs2AllOptions(argv);
       const statusLog = clean(options);
       expect(statusLog).toBe('');
     });
@@ -38,7 +38,7 @@ describe('using the cli', () => {
         out_dir: tmpDir,
         '$0': 'bin\\webdriver-manager'
       };
-      const options = constructAllProviders(argv);
+      const options = convertArgs2AllOptions(argv);
       const statusLog = clean(options);
       expect(statusLog).toBe('');
     });

--- a/lib/cmds/clean.spec-int.ts
+++ b/lib/cmds/clean.spec-int.ts
@@ -6,7 +6,7 @@ import * as rimraf from 'rimraf';
 import * as yargs from 'yargs';
 
 import {clean} from './clean';
-import {constructAllProviders} from './utils';
+import {convertArgs2AllOptions} from './utils';
 
 const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
@@ -17,7 +17,7 @@ const argv: yargs.Arguments = {
   out_dir: tmpDir,
   '$0': 'bin\\webdriver-manager'
 };
-const options = constructAllProviders(argv);
+const options = convertArgs2AllOptions(argv);
 
 describe('clean cmd', () => {
   describe('with files', () => {

--- a/lib/cmds/clean.ts
+++ b/lib/cmds/clean.ts
@@ -1,7 +1,8 @@
 import * as loglevel from 'loglevel';
 import * as yargs from 'yargs';
 import {Options} from './options';
-import {constructAllProviders} from './utils';
+import {OptionsBinary} from './options_binary';
+import {addOptionsBinary, convertArgs2AllOptions} from './utils';
 
 const log = loglevel.getLogger('webdriver-manager');
 
@@ -11,7 +12,7 @@ const log = loglevel.getLogger('webdriver-manager');
  */
 export function handler(argv: yargs.Arguments) {
   log.setLevel(argv.log_level);
-  const options = constructAllProviders(argv);
+  const options = convertArgs2AllOptions(argv);
   log.info(clean(options));
 }
 
@@ -21,16 +22,25 @@ export function handler(argv: yargs.Arguments) {
  * @returns A list of deleted files.
  */
 export function clean(options: Options): string {
-  const filesCleaned: string[] = [];
+  const optionsBinary = addOptionsBinary(options);
+  return cleanBinary(optionsBinary);
+}
 
-  for (const provider of options.providers) {
-    const cleanedFiles = provider.binary.cleanFiles();
+/**
+ * Goes through all the providers and removes the downloaded files.
+ * @param optionsBinary The constructed set of all options with binaries.
+ * @returns A list of deleted files.
+ */
+export function cleanBinary(optionsBinary: OptionsBinary): string {
+  const filesCleaned: string[] = [];
+  for (const browserDriver of optionsBinary.browserDrivers) {
+    const cleanedFiles = browserDriver.binary.cleanFiles();
     if (cleanedFiles) {
       filesCleaned.push(cleanedFiles);
     }
   }
-  if (options.server && options.server.binary) {
-    const cleanedFiles = options.server.binary.cleanFiles();
+  if (optionsBinary.server && optionsBinary.server.binary) {
+    const cleanedFiles = optionsBinary.server.binary.cleanFiles();
     if (cleanedFiles) {
       filesCleaned.push(cleanedFiles);
     }

--- a/lib/cmds/cmds.spec-e2e.ts
+++ b/lib/cmds/cmds.spec-e2e.ts
@@ -5,11 +5,12 @@ import * as path from 'path';
 import * as rimraf from 'rimraf';
 
 import {SeleniumServer} from '../provider/selenium_server';
+
 import {clean} from './clean';
-import {start} from './start';
+import {startBinary} from './start';
 import {status} from './status';
 import {update} from './update';
-import {constructAllProviders, constructProviders,} from './utils';
+import {addOptionsBinary, convertArgs2AllOptions, convertArgs2Options} from './utils';
 
 const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
@@ -43,7 +44,7 @@ describe('using the cli', () => {
         out_dir: tmpDir,
         '$0': 'bin\\webdriver-manager'
       };
-      const options = constructProviders(argv);
+      const options = convertArgs2Options(argv);
       await update(options);
       const existFiles = fs.readdirSync(tmpDir);
       expect(existFiles.length).toBe(7);
@@ -57,7 +58,7 @@ describe('using the cli', () => {
         out_dir: tmpDir,
         '$0': 'bin\\webdriver-manager'
       };
-      const options = constructAllProviders(argv);
+      const options = convertArgs2AllOptions(argv);
       const statusLog = status(options);
       log.debug(statusLog);
       const lines = statusLog.split('\n');
@@ -75,16 +76,17 @@ describe('using the cli', () => {
         out_dir: tmpDir,
         '$0': 'bin\\webdriver-manager'
       };
-      const options = constructProviders(argv);
+      const options = convertArgs2Options(argv);
+      const optionsBinary = addOptionsBinary(options);
       // Do not await this promise to start the server since the promise is
       // never resolved by waiting, it is either killed by pid or get request.
-      const startProcess = start(options);
+      const startProcess = startBinary(optionsBinary);
 
       // Arbitrarily wait for the server to start.
       await new Promise((resolve, _) => {
         setTimeout(resolve, 3000);
       });
-      const seleniumServer = (options.server.binary as SeleniumServer);
+      const seleniumServer = (optionsBinary.server.binary as SeleniumServer);
       expect(seleniumServer.seleniumProcess).toBeTruthy();
       expect(seleniumServer.seleniumProcess.pid).toBeTruthy();
 
@@ -94,6 +96,9 @@ describe('using the cli', () => {
 
       // Check to see that the exit code is 0.
       expect(await startProcess).toBe(0);
+      await new Promise((resolve, _) => {
+        setTimeout(resolve, 5000);
+      });
     });
 
     it('should start the selenium server standalone', async () => {
@@ -104,16 +109,17 @@ describe('using the cli', () => {
         out_dir: tmpDir,
         '$0': 'bin\\webdriver-manager'
       };
-      const options = constructProviders(argv);
+      const options = convertArgs2Options(argv);
+      const optionsBinary = addOptionsBinary(options);
       // Do not await this promise to start the server since the promise is
       // never resolved by waiting, it is either killed by pid or get request.
-      const startProcess = start(options);
+      const startProcess = startBinary(optionsBinary);
 
       // Arbitrarily wait for the server to start.
       await new Promise((resolve, _) => {
         setTimeout(resolve, 3000);
       });
-      const seleniumServer = (options.server.binary as SeleniumServer);
+      const seleniumServer = (optionsBinary.server.binary as SeleniumServer);
       expect(seleniumServer.seleniumProcess).toBeTruthy();
       expect(seleniumServer.seleniumProcess.pid).toBeTruthy();
 
@@ -124,6 +130,9 @@ describe('using the cli', () => {
       // Check to see that the exit code is greater than 1.
       // Observed to be 1 and sometimes 143.
       expect(await startProcess).toBeGreaterThanOrEqual(1);
+      await new Promise((resolve, _) => {
+        setTimeout(resolve, 5000);
+      });
     });
   });
 
@@ -134,7 +143,7 @@ describe('using the cli', () => {
         out_dir: tmpDir,
         '$0': 'bin\\webdriver-manager'
       };
-      const options = constructAllProviders(argv);
+      const options = convertArgs2AllOptions(argv);
       const cleanLogs = clean(options);
       log.debug(cleanLogs);
       const lines = cleanLogs.split('\n');

--- a/lib/cmds/options.ts
+++ b/lib/cmds/options.ts
@@ -1,41 +1,48 @@
-import {ProviderInterface} from '../provider/provider';
-
 /**
  * An options object to update and start the server.
  */
 export interface Options {
-  /**
-   * A provider contains information about a browser driver not including
-   * the server.
-   */
-  providers?: Array<{
-    // The name of the binary.
-    name?: string;
-    // The version which does not have to follow semver.
-    version?: string;
-    // The binary provider object.
-    binary?: ProviderInterface;
-  }>;
-  server?: {
-    // The name of the server.
-    name?: string;
-    // The version which does not have to follow semver.
-    version?: string;
-    // The server binary object.
-    binary?: ProviderInterface;
-    // Run as role = node option.
-    runAsNode?: boolean;
-    // The relative or full path to the chrome logs file
-    chrome_logs?: string;
-    // The full path to the edge driver server
-    edge?: string;
-    // Detach the server and return the process to the parent.
-    runAsDetach?: boolean;
-  };
+  // A list of browser drivers.
+  browserDrivers?: BrowserDriver[];
+  // The server.
+  server?: Server;
   // The proxy url (must include protocol with url)
   proxy?: string;
   // To ignore SSL certs when making requests.
   ignoreSSL?: boolean;
   // The location where files should be saved.
   outDir?: string;
+  // Use a github token for github requests.
+  githubToken?: string;
+}
+
+/**
+ * Contains information about a browser driver.
+ */
+export interface BrowserDriver {
+  // The name of the browser driver.
+  name?: 'chromedriver'|'geckodriver'|'iedriver';
+  // The version which does not have to follow semver.
+  version?: string;
+}
+
+/**
+ * Contains information about the selenium server standalone. This includes
+ * options to start the server along with options to send to the server.
+ */
+export interface Server {
+  // The name of the server option.
+  name?: 'selenium';
+  // The version which does not have to follow semver.
+  version?: string;
+  // Run as role = node option.
+  runAsNode?: boolean;
+  // The relative or full path to the chrome logs file.
+  chrome_logs?: string;
+  // The full path to the edge driver server.
+  edge?: string;
+  // Detach the server and return the process to the parent.
+  runAsDetach?: boolean;
+  // Port number to start the server.
+  port?: number;
 }

--- a/lib/cmds/options_binary.ts
+++ b/lib/cmds/options_binary.ts
@@ -1,0 +1,17 @@
+import {ProviderInterface} from '../provider/provider';
+import {BrowserDriver, Options, Server} from './options';
+
+export interface OptionsBinary extends Options {
+  browserDrivers?: BrowserDriverBinary[];
+  server?: ServerBinary;
+}
+
+export interface BrowserDriverBinary extends BrowserDriver {
+  // The binary provider object.
+  binary?: ProviderInterface;
+}
+
+export interface ServerBinary extends Server {
+  // The binary provider object.
+  binary?: ProviderInterface;
+}

--- a/lib/cmds/shutdown.ts
+++ b/lib/cmds/shutdown.ts
@@ -3,6 +3,8 @@ import * as yargs from 'yargs';
 
 import {SeleniumServer} from '../provider/selenium_server';
 import {Options} from './options';
+import {OptionsBinary} from './options_binary';
+import {addOptionsBinary} from './utils';
 
 const log = loglevel.getLogger('webdriver-manager');
 
@@ -26,6 +28,17 @@ export async function handler(argv: yargs.Arguments) {
  * @returns A promise for the get request.
  */
 export function shutdown(options: Options): Promise<void> {
-  const seleniumServer = options.server.binary as SeleniumServer;
+  const optionsBinary = addOptionsBinary(options);
+  return shutdownBinary(optionsBinary);
+}
+
+/**
+ * Shutodown the selenium server with a get request. If the server is not
+ * started with role = node, nothing will happen.
+ * @param optionsBinary The constructed option for the server with binary.
+ * @returns A promise for the get request.
+ */
+export function shutdownBinary(optionsBinary: OptionsBinary): Promise<void> {
+  const seleniumServer = optionsBinary.server.binary as SeleniumServer;
   return seleniumServer.stopServer();
 }

--- a/lib/cmds/status.spec-e2e.ts
+++ b/lib/cmds/status.spec-e2e.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as rimraf from 'rimraf';
 
 import {status} from './status';
-import {constructAllProviders} from './utils';
+import {convertArgs2AllOptions} from './utils';
 
 const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
@@ -27,7 +27,7 @@ describe('using the cli', () => {
         out_dir: tmpDir,
         '$0': 'bin\\webdriver-manager'
       };
-      const options = constructAllProviders(argv);
+      const options = convertArgs2AllOptions(argv);
       const statusLog = status(options);
       expect(statusLog).toBe('');
     });
@@ -39,7 +39,7 @@ describe('using the cli', () => {
         out_dir: tmpDir,
         '$0': 'bin\\webdriver-manager'
       };
-      const options = constructAllProviders(argv);
+      const options = convertArgs2AllOptions(argv);
       const statusLog = status(options);
       expect(statusLog).toBe('');
     });

--- a/lib/cmds/status.spec-int.ts
+++ b/lib/cmds/status.spec-int.ts
@@ -5,8 +5,8 @@ import * as path from 'path';
 import * as rimraf from 'rimraf';
 import * as yargs from 'yargs';
 
-import {status} from './status';
-import {constructAllProviders} from './utils';
+import {statusBinary} from './status';
+import {addOptionsBinary, convertArgs2AllOptions} from './utils';
 
 const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
@@ -17,11 +17,12 @@ const argv: yargs.Arguments = {
   out_dir: tmpDir,
   '$0': 'bin\\webdriver-manager'
 };
-const options = constructAllProviders(argv);
-for (const provider of options.providers) {
-  provider.binary.osType = 'Linux';
+const options = convertArgs2AllOptions(argv);
+const optionsBinary = addOptionsBinary(options);
+for (const browserDriver of optionsBinary.browserDrivers) {
+  browserDriver.binary.osType = 'Linux';
 }
-options.server.binary.osType = 'Linux';
+optionsBinary.server.binary.osType = 'Linux';
 
 describe('status cmd', () => {
   describe('with files', () => {
@@ -48,7 +49,7 @@ describe('status cmd', () => {
     });
 
     it('should get the status for chromedriver', () => {
-      const lines = status(options).split('\n');
+      const lines = statusBinary(optionsBinary).split('\n');
       expect(lines.length).toBe(1);
       expect(lines[0]).toBe('chromedriver: 2.20, 2.41 (latest)');
     });

--- a/lib/cmds/status.ts
+++ b/lib/cmds/status.ts
@@ -1,7 +1,8 @@
 import * as loglevel from 'loglevel';
 import * as yargs from 'yargs';
 import {Options} from './options';
-import {constructAllProviders} from './utils';
+import {OptionsBinary} from './options_binary';
+import {addOptionsBinary, convertArgs2AllOptions} from './utils';
 
 const log = loglevel.getLogger('webdriver-manager');
 
@@ -11,7 +12,7 @@ const log = loglevel.getLogger('webdriver-manager');
  */
 export function handler(argv: yargs.Arguments) {
   log.setLevel(argv.log_level);
-  const options = constructAllProviders(argv);
+  const options = convertArgs2AllOptions(argv);
   console.log(status(options));
 }
 
@@ -21,17 +22,27 @@ export function handler(argv: yargs.Arguments) {
  * @returns A string of the versions downloaded.
  */
 export function status(options: Options): string {
+  const optionsBinary = addOptionsBinary(options);
+  return statusBinary(optionsBinary);
+}
+
+/**
+ * Gets a list of versions for server and browser drivers.
+ * @param optionsBinary The constructed set of all options with binaries.
+ * @returns A string of the versions downloaded.
+ */
+export function statusBinary(optionsBinary: OptionsBinary): string {
   const binaryVersions = [];
-  for (const provider of options.providers) {
-    const status = provider.binary.getStatus();
+  for (const browserDriver of optionsBinary.browserDrivers) {
+    const status = browserDriver.binary.getStatus();
     if (status) {
-      binaryVersions.push(`${provider.name}: ${status}`);
+      binaryVersions.push(`${browserDriver.name}: ${status}`);
     }
   }
-  if (options.server && options.server.binary) {
-    const status = options.server.binary.getStatus();
+  if (optionsBinary.server && optionsBinary.server.binary) {
+    const status = optionsBinary.server.binary.getStatus();
     if (status) {
-      binaryVersions.push(`${options.server.name}: ${status}`);
+      binaryVersions.push(`${optionsBinary.server.name}: ${status}`);
     }
   }
   return (binaryVersions.sort()).join('\n');

--- a/lib/cmds/update.spec-int.ts
+++ b/lib/cmds/update.spec-int.ts
@@ -8,8 +8,8 @@ import {ChromeDriver} from '../provider/chromedriver';
 import {GeckoDriver} from '../provider/geckodriver';
 import {IEDriver} from '../provider/iedriver';
 import {SeleniumServer} from '../provider/selenium_server';
-import {Options} from './options';
-import {update} from './update';
+import {OptionsBinary} from './options_binary';
+import {updateBinary} from './update';
 
 const log = loglevel.getLogger('webdriver-manager-test');
 log.setLevel('debug');
@@ -43,50 +43,51 @@ describe('update cmd', () => {
   });
 
   it('should download the chromdriver files', async () => {
-    const options: Options = {
+    const optionsBinary: OptionsBinary = {
       outDir: tmpDir,
-      providers: [{binary: new ChromeDriver({outDir: tmpDir})}]
+      browserDrivers: [{binary: new ChromeDriver({outDir: tmpDir})}]
     };
-    await update(options);
+    await updateBinary(optionsBinary);
     expect(fs.readdirSync(tmpDir).length).toBe(4);
   });
 
   it('should download the geckodriver files', async () => {
-    const options: Options = {
+    const optionsBinary: OptionsBinary = {
       outDir: tmpDir,
-      providers: [{binary: new GeckoDriver({outDir: tmpDir})}]
+      browserDrivers: [{binary: new GeckoDriver({outDir: tmpDir})}]
     };
-    await update(options);
+    await updateBinary(optionsBinary);
     expect(fs.readdirSync(tmpDir).length).toBe(4);
   });
 
   it('should download selenium server files', async () => {
-    const options: Options = {
+    const optionsBinary: OptionsBinary = {
       outDir: tmpDir,
       server: {binary: new SeleniumServer({outDir: tmpDir})}
     };
-    await update(options);
+    await updateBinary(optionsBinary);
     expect(fs.readdirSync(tmpDir).length).toBe(3);
   });
 
   it('should download iedriver files', async () => {
     const iedriver = new IEDriver({outDir: tmpDir});
     iedriver.osType = 'Windows_NT';
-    const options: Options = {outDir: tmpDir, providers: [{binary: iedriver}]};
-    await update(options);
+    const optionsBinary:
+        OptionsBinary = {outDir: tmpDir, browserDrivers: [{binary: iedriver}]};
+    await updateBinary(optionsBinary);
     expect(fs.readdirSync(tmpDir).length).toBe(4);
   });
 
   it('should download default files', async () => {
-    const options: Options = {
+    const optionsBinary: OptionsBinary = {
       outDir: tmpDir,
-      providers: [
+      browserDrivers: [
         {binary: new ChromeDriver({outDir: tmpDir})},
         {binary: new GeckoDriver({outDir: tmpDir})},
       ],
       server: {binary: new SeleniumServer({outDir: tmpDir})}
     };
-    await update(options);
+    await updateBinary(optionsBinary);
     expect(fs.readdirSync(tmpDir).length).toBe(11);
   });
 });

--- a/lib/cmds/update.ts
+++ b/lib/cmds/update.ts
@@ -1,7 +1,8 @@
 import * as loglevel from 'loglevel';
 import * as yargs from 'yargs';
 import {Options} from './options';
-import {constructProviders} from './utils';
+import {OptionsBinary} from './options_binary';
+import {addOptionsBinary, convertArgs2Options} from './utils';
 
 const log = loglevel.getLogger('webdriver-manager');
 
@@ -11,7 +12,7 @@ const log = loglevel.getLogger('webdriver-manager');
  */
 export async function handler(argv: yargs.Arguments) {
   log.setLevel(argv.log_level);
-  const options = constructProviders(argv);
+  const options = convertArgs2Options(argv);
   await update(options);
 }
 
@@ -21,14 +22,25 @@ export async function handler(argv: yargs.Arguments) {
  * @returns Promise when binaries are all downloaded.
  */
 export function update(options: Options): Promise<void[]> {
+  const optionsBinary = addOptionsBinary(options);
+  return updateBinary(optionsBinary);
+}
+
+/**
+ * Updates / downloads the providers binaries.
+ * @param optionsBinary The constructed options with binaries.
+ * @returns Promise when binaries are all downloaded.
+ */
+export function updateBinary(optionsBinary: OptionsBinary): Promise<void[]> {
   const promises = [];
-  if (options.providers) {
-    for (const provider of options.providers) {
+  if (optionsBinary.browserDrivers) {
+    for (const provider of optionsBinary.browserDrivers) {
       promises.push(provider.binary.updateBinary(provider.version));
     }
   }
-  if (options.server && options.server.binary) {
-    promises.push(options.server.binary.updateBinary(options.server.version));
+  if (optionsBinary.server && optionsBinary.server.binary) {
+    promises.push(
+        optionsBinary.server.binary.updateBinary(optionsBinary.server.version));
   }
   return Promise.all(promises);
 }

--- a/lib/cmds/utils.spec-unit.ts
+++ b/lib/cmds/utils.spec-unit.ts
@@ -1,7 +1,7 @@
-import {constructAllProviders, constructProviders,} from './utils';
+import {convertArgs2AllOptions, convertArgs2Options} from './utils';
 
 describe('utils', () => {
-  describe('constructAllProviders', () => {
+  describe('convertArgs2AllOptions', () => {
     it('should create all providers', () => {
       const argv = {
         _: ['foobar'],
@@ -11,10 +11,10 @@ describe('utils', () => {
         ignore_ssl: false,
         '$0': 'bin\\webdriver-manager'
       };
-      const options = constructAllProviders(argv);
-      expect(options.providers).toBeTruthy();
-      expect(options.providers.length).toBe(3);
-      for (const provider of options.providers) {
+      const options = convertArgs2AllOptions(argv);
+      expect(options.browserDrivers).toBeTruthy();
+      expect(options.browserDrivers.length).toBe(3);
+      for (const provider of options.browserDrivers) {
         if (provider.name === 'geckodriver') {
           expect(provider.version).toBe('0.16.0');
         }
@@ -24,18 +24,17 @@ describe('utils', () => {
         if (provider.name === 'iedriver') {
           expect(provider.version).toBeUndefined();
         }
-        expect(provider.binary).toBeTruthy();
       }
       expect(options.server).toBeTruthy();
       expect(options.server.name).toBe('selenium');
       expect(options.server.version).toBeUndefined();
-      expect(options.server.binary).toBeTruthy();
       expect(options.proxy).toBe('http://some.proxy.com');
       expect(options.ignoreSSL).toBeFalsy();
       expect(options.outDir).toBe('foobar_download');
     });
   });
-  describe('constructProviders', () => {
+
+  describe('convertArgs2Options', () => {
     it('should create the default providers', () => {
       const argv = {
         _: ['foobar'],
@@ -46,22 +45,20 @@ describe('utils', () => {
         out_dir: 'foobar_download',
         '$0': 'bin\\webdriver-manager'
       };
-      const options = constructProviders(argv);
-      expect(options.providers).toBeTruthy();
-      expect(options.providers.length).toBe(2);
-      for (const provider of options.providers) {
+      const options = convertArgs2Options(argv);
+      expect(options.browserDrivers).toBeTruthy();
+      expect(options.browserDrivers.length).toBe(2);
+      for (const provider of options.browserDrivers) {
         if (provider.name === 'geckodriver') {
           expect(provider.version).toBe('0.16.0');
         }
         if (provider.name === 'chromedriver') {
           expect(provider.version).toBe('2.20');
         }
-        expect(provider.binary).toBeTruthy();
       }
       expect(options.server).toBeTruthy();
       expect(options.server.name).toBe('selenium');
       expect(options.server.version).toBeUndefined();
-      expect(options.server.binary).toBeTruthy();
       expect(options.proxy).toBeUndefined();
       expect(options.ignoreSSL).toBeUndefined();
     });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,7 +12,6 @@ export {shutdown} from './cmds/shutdown';
 export {start} from './cmds/start';
 export {status} from './cmds/status';
 export {update} from './cmds/update';
-export {initOptions, Provider} from './cmds/utils';
 export {ChromeDriver} from './provider/chromedriver';
 export {GeckoDriver} from './provider/geckodriver';
 export {IEDriver} from './provider/iedriver';

--- a/lib/provider/appium.spec-int.ts
+++ b/lib/provider/appium.spec-int.ts
@@ -12,33 +12,44 @@ describe('appium', () => {
   let origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
   describe('getVersion', () => {
     let proc: childProcess.ChildProcess;
-    beforeAll((done) => {
+
+    beforeAll(() => {
       jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
-      proc = spawnProcess('node', ['dist/spec/server/http_server.js']);
-      console.log('http-server: ' + proc.pid);
-      try {
-        fs.mkdirSync(tmpDir);
-      } catch (err) {
-      }
-      setTimeout(done, 3000);
     });
 
     afterAll(() => {
-      try {
-        rimraf.sync(tmpDir);
-      } catch (err) {
-      }
-      process.kill(proc.pid);
       jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
     });
 
-    it('should get the version from the local server', async () => {
-      const appium = new Appium({
-        outDir: tmpDir,
-        requestUrl: 'http://127.0.0.1:8812/spec/support/files/appium.json'
+    describe('with a http server', () => {
+      beforeAll(async () => {
+        proc = spawnProcess('node', ['dist/spec/server/http_server.js']);
+        console.log('http-server: ' + proc.pid);
+        try {
+          fs.mkdirSync(tmpDir);
+        } catch (err) {
+        }
+        await new Promise((resolve, _) => {
+          setTimeout(resolve, 3000);
+        });
       });
-      expect(await appium.getVersion()).toBe('10.11.12');
-    });
+  
+      afterAll(() => {
+        try {
+          rimraf.sync(tmpDir);
+        } catch (err) {
+        }
+        process.kill(proc.pid);
+      });
+
+      it('should get the version from the local server', async () => {
+        const appium = new Appium({
+          outDir: tmpDir,
+          requestUrl: 'http://127.0.0.1:8812/spec/support/files/appium.json'
+        });
+        expect(await appium.getVersion()).toBe('10.11.12');
+      });
+    });    
   });
 
   describe('setup', () => {

--- a/lib/provider/chromedriver.spec-int.ts
+++ b/lib/provider/chromedriver.spec-int.ts
@@ -13,10 +13,16 @@ describe('chromedriver', () => {
 
   describe('class ChromeDriver', () => {
     const origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    beforeAll(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+    });
+
+    afterAll(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
+    });
 
     describe('updateBinary', () => {
-      beforeEach(() => {
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+      beforeEach(() => {        
         try {
           fs.mkdirSync(tmpDir);
         } catch (err) {
@@ -24,114 +30,101 @@ describe('chromedriver', () => {
       });
 
       afterEach(() => {
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
         try {
           rimraf.sync(tmpDir);
         } catch (err) {
         }
       });
 
-      it('should download the latest for MacOS', async (done) => {
-        if (!await checkConnectivity('update binary for mac test')) {
-          done();
+      it('should download the latest for MacOS', async () => {
+        if (await checkConnectivity('update binary for mac test')) {
+          const chromedriver =
+              new ChromeDriver({outDir: tmpDir, osType: 'Darwin'});
+          await chromedriver.updateBinary();
+
+          const configFile = path.resolve(tmpDir, 'chromedriver.config.json');
+          const xmlFile = path.resolve(tmpDir, 'chromedriver.xml');
+          expect(fs.statSync(configFile).size).toBeTruthy();
+          expect(fs.statSync(xmlFile).size).toBeTruthy();
+
+          const versionList = convertXmlToVersionList(
+              xmlFile, '.zip', versionParser, semanticVersionParser);
+          const versionObj = getVersion(versionList, 'mac');
+          const executableFile =
+              path.resolve(tmpDir, 'chromedriver_' + versionObj.version);
+          expect(fs.statSync(executableFile).size).toBeTruthy();
         }
-        const chromedriver =
-            new ChromeDriver({outDir: tmpDir, osType: 'Darwin'});
-        await chromedriver.updateBinary();
-
-        const configFile = path.resolve(tmpDir, 'chromedriver.config.json');
-        const xmlFile = path.resolve(tmpDir, 'chromedriver.xml');
-        expect(fs.statSync(configFile).size).toBeTruthy();
-        expect(fs.statSync(xmlFile).size).toBeTruthy();
-
-        const versionList = convertXmlToVersionList(
-            xmlFile, '.zip', versionParser, semanticVersionParser);
-        const versionObj = getVersion(versionList, 'mac');
-        const executableFile =
-            path.resolve(tmpDir, 'chromedriver_' + versionObj.version);
-        expect(fs.statSync(executableFile).size).toBeTruthy();
-        done();
       });
 
-      it('should download the latest for Windows x64', async (done) => {
-        if (!await checkConnectivity('update binary for win x64 test')) {
-          done();
+      it('should download the latest for Windows x64', async () => {
+        if (await checkConnectivity('update binary for win x64 test')) {
+          const chromedriver = new ChromeDriver(
+              {outDir: tmpDir, osType: 'Windows_NT', osArch: 'x64'});
+          await chromedriver.updateBinary();
+
+          const configFile = path.resolve(tmpDir, 'chromedriver.config.json');
+          const xmlFile = path.resolve(tmpDir, 'chromedriver.xml');
+          expect(fs.statSync(configFile).size).toBeTruthy();
+          expect(fs.statSync(xmlFile).size).toBeTruthy();
+
+          const versionList = convertXmlToVersionList(
+              xmlFile, '.zip', versionParser, semanticVersionParser);
+          const versionObj = getVersion(versionList, 'win32');
+          const executableFile =
+              path.resolve(tmpDir, 'chromedriver_' + versionObj.version + '.exe');
+          expect(fs.statSync(executableFile).size).toBeTruthy(); 
         }
-        const chromedriver = new ChromeDriver(
-            {outDir: tmpDir, osType: 'Windows_NT', osArch: 'x64'});
-        await chromedriver.updateBinary();
-
-        const configFile = path.resolve(tmpDir, 'chromedriver.config.json');
-        const xmlFile = path.resolve(tmpDir, 'chromedriver.xml');
-        expect(fs.statSync(configFile).size).toBeTruthy();
-        expect(fs.statSync(xmlFile).size).toBeTruthy();
-
-        const versionList = convertXmlToVersionList(
-            xmlFile, '.zip', versionParser, semanticVersionParser);
-        const versionObj = getVersion(versionList, 'win32');
-        const executableFile =
-            path.resolve(tmpDir, 'chromedriver_' + versionObj.version + '.exe');
-        expect(fs.statSync(executableFile).size).toBeTruthy();
-        done();
       });
 
-      it('should download the latest for Windows x32', async (done) => {
-        if (!await checkConnectivity('update binary for win x32 test')) {
-          done();
+      it('should download the latest for Windows x32', async () => {
+        if (await checkConnectivity('update binary for win x32 test')) {
+          const chromedriver = new ChromeDriver(
+              {outDir: tmpDir, osType: 'Windows_NT', osArch: 'x32'});
+          await chromedriver.updateBinary();
+
+          const configFile = path.resolve(tmpDir, 'chromedriver.config.json');
+          const xmlFile = path.resolve(tmpDir, 'chromedriver.xml');
+          expect(fs.statSync(configFile).size).toBeTruthy();
+          expect(fs.statSync(xmlFile).size).toBeTruthy();
+
+          const versionList = convertXmlToVersionList(
+              xmlFile, '.zip', versionParser, semanticVersionParser);
+          const versionObj = getVersion(versionList, 'win32');
+          const executableFile =
+              path.resolve(tmpDir, 'chromedriver_' + versionObj.version + '.exe');
+          expect(fs.statSync(executableFile).size).toBeTruthy();  
         }
-        const chromedriver = new ChromeDriver(
-            {outDir: tmpDir, osType: 'Windows_NT', osArch: 'x32'});
-        await chromedriver.updateBinary();
-
-        const configFile = path.resolve(tmpDir, 'chromedriver.config.json');
-        const xmlFile = path.resolve(tmpDir, 'chromedriver.xml');
-        expect(fs.statSync(configFile).size).toBeTruthy();
-        expect(fs.statSync(xmlFile).size).toBeTruthy();
-
-        const versionList = convertXmlToVersionList(
-            xmlFile, '.zip', versionParser, semanticVersionParser);
-        const versionObj = getVersion(versionList, 'win32');
-        const executableFile =
-            path.resolve(tmpDir, 'chromedriver_' + versionObj.version + '.exe');
-        expect(fs.statSync(executableFile).size).toBeTruthy();
-        done();
       });
 
-      it('should download the latest for Linux x64', async (done) => {
-        if (!await checkConnectivity('update binary for linux x64 test')) {
-          done();
+      it('should download the latest for Linux x64', async () => {
+        if (await checkConnectivity('update binary for linux x64 test')) {
+          const chromedriver =
+              new ChromeDriver({outDir: tmpDir, osType: 'Linux', osArch: 'x64'});
+          await chromedriver.updateBinary();
+
+          const configFile = path.resolve(tmpDir, 'chromedriver.config.json');
+          const xmlFile = path.resolve(tmpDir, 'chromedriver.xml');
+          expect(fs.statSync(configFile).size).toBeTruthy();
+          expect(fs.statSync(xmlFile).size).toBeTruthy();
+
+          const versionList = convertXmlToVersionList(
+              xmlFile, '.zip', versionParser, semanticVersionParser);
+          const versionObj = getVersion(versionList, 'linux64');
+          const executableFile =
+              path.resolve(tmpDir, 'chromedriver_' + versionObj.version);
+          expect(fs.statSync(executableFile).size).toBeTruthy();  
         }
-        const chromedriver =
-            new ChromeDriver({outDir: tmpDir, osType: 'Linux', osArch: 'x64'});
-        await chromedriver.updateBinary();
-
-        const configFile = path.resolve(tmpDir, 'chromedriver.config.json');
-        const xmlFile = path.resolve(tmpDir, 'chromedriver.xml');
-        expect(fs.statSync(configFile).size).toBeTruthy();
-        expect(fs.statSync(xmlFile).size).toBeTruthy();
-
-        const versionList = convertXmlToVersionList(
-            xmlFile, '.zip', versionParser, semanticVersionParser);
-        const versionObj = getVersion(versionList, 'linux64');
-        const executableFile =
-            path.resolve(tmpDir, 'chromedriver_' + versionObj.version);
-        expect(fs.statSync(executableFile).size).toBeTruthy();
-        done();
       });
 
-      it('should not download for Linux x32', async (done) => {
-        if (!await checkConnectivity('update binary for linux x32 test')) {
-          done();
+      it('should not download for Linux x32', async () => {
+        if (await checkConnectivity('update binary for linux x32 test')) {
+          const chromedriver =
+              new ChromeDriver({outDir: tmpDir, osType: 'Linux', osArch: 'x32'});
+          chromedriver.updateBinary().then(() => {
+                expect(false).toBeTruthy();
+              }).catch(() => {
+              });
         }
-        const chromedriver =
-            new ChromeDriver({outDir: tmpDir, osType: 'Linux', osArch: 'x32'});
-        chromedriver.updateBinary()
-            .then(() => {
-              done.fail();
-            })
-            .catch(() => {
-              done();
-            });
       });
     });
   });

--- a/lib/provider/geckodriver.spec-int.ts
+++ b/lib/provider/geckodriver.spec-int.ts
@@ -14,8 +14,15 @@ describe('geckodriver', () => {
 
   describe('class GeckoDriver', () => {
     describe('updateBinary', () => {
-      beforeEach(() => {
+      beforeAll(() => {
         jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+      });
+
+      afterAll(() => {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
+      });
+
+      beforeEach(() => {
         try {
           fs.mkdirSync(tmpDir);
         } catch (err) {
@@ -23,115 +30,104 @@ describe('geckodriver', () => {
       });
 
       afterEach(() => {
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
         try {
           rimraf.sync(tmpDir);
         } catch (err) {
         }
       });
 
-      it('should download the latest for MacOS', async (done) => {
-        if (!await checkConnectivity('update binary for mac test')) {
-          done();
+      it('should download the latest for MacOS', async () => {
+        if (await checkConnectivity('update binary for mac test')) {
+          const geckodriver = new GeckoDriver({outDir: tmpDir, osType: 'Darwin'});
+          await geckodriver.updateBinary();
+  
+          const configFile = path.resolve(tmpDir, 'geckodriver.config.json');
+          const jsonFile = path.resolve(tmpDir, 'geckodriver.json');
+          expect(fs.statSync(configFile).size).toBeTruthy();
+          expect(fs.statSync(jsonFile).size).toBeTruthy();
+  
+          const versionList = convertJsonToVersionList(jsonFile);
+          const versionObj = getVersion(versionList, 'macos');
+          const executableFile =
+              path.resolve(tmpDir, 'geckodriver_' + versionObj.version);
+          expect(fs.statSync(executableFile).size).toBeTruthy(); 
         }
-        const geckodriver = new GeckoDriver({outDir: tmpDir, osType: 'Darwin'});
-        await geckodriver.updateBinary();
-
-        const configFile = path.resolve(tmpDir, 'geckodriver.config.json');
-        const jsonFile = path.resolve(tmpDir, 'geckodriver.json');
-        expect(fs.statSync(configFile).size).toBeTruthy();
-        expect(fs.statSync(jsonFile).size).toBeTruthy();
-
-        const versionList = convertJsonToVersionList(jsonFile);
-        const versionObj = getVersion(versionList, 'macos');
-        const executableFile =
-            path.resolve(tmpDir, 'geckodriver_' + versionObj.version);
-        expect(fs.statSync(executableFile).size).toBeTruthy();
-        done();
       });
 
-      it('should download the latest for Windows x64', async (done) => {
-        if (!await checkConnectivity('update binary for win64 test')) {
-          done();
-        }
-        const geckodriver = new GeckoDriver(
+      it('should download the latest for Windows x64', async () => {
+        if (await checkConnectivity('update binary for win64 test')) {
+          const geckodriver = new GeckoDriver(
             {outDir: tmpDir, osType: 'Windows_NT', osArch: 'x64'});
-        await geckodriver.updateBinary();
+          await geckodriver.updateBinary();
 
-        const configFile = path.resolve(tmpDir, 'geckodriver.config.json');
-        const jsonFile = path.resolve(tmpDir, 'geckodriver.json');
-        expect(fs.statSync(configFile).size).toBeTruthy();
-        expect(fs.statSync(jsonFile).size).toBeTruthy();
+          const configFile = path.resolve(tmpDir, 'geckodriver.config.json');
+          const jsonFile = path.resolve(tmpDir, 'geckodriver.json');
+          expect(fs.statSync(configFile).size).toBeTruthy();
+          expect(fs.statSync(jsonFile).size).toBeTruthy();
 
-        const versionList = convertJsonToVersionList(jsonFile);
-        const versionObj = getVersion(versionList, 'win64');
-        const executableFile =
-            path.resolve(tmpDir, 'geckodriver_' + versionObj.version + '.exe');
-        expect(fs.statSync(executableFile).size).toBeTruthy();
-        done();
+          const versionList = convertJsonToVersionList(jsonFile);
+          const versionObj = getVersion(versionList, 'win64');
+          const executableFile =
+              path.resolve(tmpDir, 'geckodriver_' + versionObj.version + '.exe');
+          expect(fs.statSync(executableFile).size).toBeTruthy();
+        }
       });
 
-      it('should download the latest for Windows x32', async (done) => {
-        if (!await checkConnectivity('update binary for win32 test')) {
-          done();
-        }
-        const geckodriver = new GeckoDriver(
+      it('should download the latest for Windows x32', async () => {
+        if (await checkConnectivity('update binary for win32 test')) {
+          const geckodriver = new GeckoDriver(
             {outDir: tmpDir, osType: 'Windows_NT', osArch: 'x32'});
-        await geckodriver.updateBinary();
+          await geckodriver.updateBinary();
 
-        const configFile = path.resolve(tmpDir, 'geckodriver.config.json');
-        const jsonFile = path.resolve(tmpDir, 'geckodriver.json');
-        expect(fs.statSync(configFile).size).toBeTruthy();
-        expect(fs.statSync(jsonFile).size).toBeTruthy();
+          const configFile = path.resolve(tmpDir, 'geckodriver.config.json');
+          const jsonFile = path.resolve(tmpDir, 'geckodriver.json');
+          expect(fs.statSync(configFile).size).toBeTruthy();
+          expect(fs.statSync(jsonFile).size).toBeTruthy();
 
-        const versionList = convertJsonToVersionList(jsonFile);
-        const versionObj = getVersion(versionList, 'win64');
-        const executableFile =
-            path.resolve(tmpDir, 'geckodriver_' + versionObj.version + '.exe');
-        expect(fs.statSync(executableFile).size).toBeTruthy();
-        done();
+          const versionList = convertJsonToVersionList(jsonFile);
+          const versionObj = getVersion(versionList, 'win64');
+          const executableFile =
+              path.resolve(tmpDir, 'geckodriver_' + versionObj.version + '.exe');
+          expect(fs.statSync(executableFile).size).toBeTruthy();
+        }
       });
 
-      it('should download the latest for Linux x64', async (done) => {
-        if (!await checkConnectivity('update binary for linux64 test')) {
-          done();
+      it('should download the latest for Linux x64', async () => {
+        if (await checkConnectivity('update binary for linux64 test')) {
+          const geckodriver =
+              new GeckoDriver({outDir: tmpDir, osType: 'Linux', osArch: 'x64'});
+          await geckodriver.updateBinary();
+
+          const configFile = path.resolve(tmpDir, 'geckodriver.config.json');
+          const jsonFile = path.resolve(tmpDir, 'geckodriver.json');
+          expect(fs.statSync(configFile).size).toBeTruthy();
+          expect(fs.statSync(jsonFile).size).toBeTruthy();
+
+          const versionList = convertJsonToVersionList(jsonFile);
+          const versionObj = getVersion(versionList, 'linux64');
+          const executableFile =
+              path.resolve(tmpDir, 'geckodriver_' + versionObj.version);
+          expect(fs.statSync(executableFile).size).toBeTruthy(); 
         }
-        const geckodriver =
-            new GeckoDriver({outDir: tmpDir, osType: 'Linux', osArch: 'x64'});
-        await geckodriver.updateBinary();
-
-        const configFile = path.resolve(tmpDir, 'geckodriver.config.json');
-        const jsonFile = path.resolve(tmpDir, 'geckodriver.json');
-        expect(fs.statSync(configFile).size).toBeTruthy();
-        expect(fs.statSync(jsonFile).size).toBeTruthy();
-
-        const versionList = convertJsonToVersionList(jsonFile);
-        const versionObj = getVersion(versionList, 'linux64');
-        const executableFile =
-            path.resolve(tmpDir, 'geckodriver_' + versionObj.version);
-        expect(fs.statSync(executableFile).size).toBeTruthy();
-        done();
       });
 
-      it('should download the latest for Linux x32', async (done) => {
-        if (!await checkConnectivity('update binary for linux32 test')) {
-          done();
+      it('should download the latest for Linux x32', async () => {
+        if (await checkConnectivity('update binary for linux32 test')) {
+          const geckodriver =
+              new GeckoDriver({outDir: tmpDir, osType: 'Linux', osArch: 'x32'});
+          await geckodriver.updateBinary();
+
+          const configFile = path.resolve(tmpDir, 'geckodriver.config.json');
+          const jsonFile = path.resolve(tmpDir, 'geckodriver.json');
+          expect(fs.statSync(configFile).size).toBeTruthy();
+          expect(fs.statSync(jsonFile).size).toBeTruthy();
+
+          const versionList = convertJsonToVersionList(jsonFile);
+          const versionObj = getVersion(versionList, 'linux32');
+          const executableFile =
+              path.resolve(tmpDir, 'geckodriver_' + versionObj.version);
+          expect(fs.statSync(executableFile).size).toBeTruthy();  
         }
-        const geckodriver =
-            new GeckoDriver({outDir: tmpDir, osType: 'Linux', osArch: 'x32'});
-        await geckodriver.updateBinary();
-
-        const configFile = path.resolve(tmpDir, 'geckodriver.config.json');
-        const jsonFile = path.resolve(tmpDir, 'geckodriver.json');
-        expect(fs.statSync(configFile).size).toBeTruthy();
-        expect(fs.statSync(jsonFile).size).toBeTruthy();
-
-        const versionList = convertJsonToVersionList(jsonFile);
-        const versionObj = getVersion(versionList, 'linux32');
-        const executableFile =
-            path.resolve(tmpDir, 'geckodriver_' + versionObj.version);
-        expect(fs.statSync(executableFile).size).toBeTruthy();
-        done();
       });
     });
   });

--- a/lib/provider/geckodriver.ts
+++ b/lib/provider/geckodriver.ts
@@ -8,6 +8,10 @@ import {convertJsonToVersionList, updateJson} from './utils/github_json';
 import {requestBinary} from './utils/http_utils';
 import {getVersion} from './utils/version_list';
 
+export interface GeckoDriverProviderConfig extends ProviderConfig {
+  oauthToken?: string;
+}
+
 export class GeckoDriver implements ProviderInterface {
   cacheFileName = 'geckodriver.json';
   configFileName = 'geckodriver.config.json';
@@ -20,7 +24,7 @@ export class GeckoDriver implements ProviderInterface {
   requestUrl = 'https://api.github.com/repos/mozilla/geckodriver/releases';
   seleniumFlag = '-Dwebdriver.gecko.driver';
 
-  constructor(providerConfig?: ProviderConfig) {
+  constructor(providerConfig?: GeckoDriverProviderConfig) {
     if (providerConfig) {
       if (providerConfig.cacheFileName) {
         this.cacheFileName = providerConfig.cacheFileName;
@@ -45,7 +49,7 @@ export class GeckoDriver implements ProviderInterface {
         this.requestUrl = providerConfig.requestUrl;
       }
       if (providerConfig.oauthToken) {
-        this.oauthToken = providerConfig.oauthToken as string;
+        this.oauthToken = providerConfig.oauthToken;
       }
     }
   }

--- a/lib/provider/iedriver.spec-int.ts
+++ b/lib/provider/iedriver.spec-int.ts
@@ -14,8 +14,15 @@ describe('iedriver', () => {
     const tmpDir = path.resolve(os.tmpdir(), 'test');
     const origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
 
-    beforeEach(() => {
+    beforeAll(() => {
       jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+    });
+
+    afterAll(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
+    });
+
+    beforeEach(() => {
       try {
         fs.mkdirSync(tmpDir);
       } catch (err) {
@@ -23,18 +30,15 @@ describe('iedriver', () => {
     });
 
     afterEach(() => {
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
       try {
         rimraf.sync(tmpDir);
       } catch (err) {
       }
     });
 
-    it('should download the file', async (done) => {
-      if (!await checkConnectivity('update binary for windows test')) {
-        done();
-      }
-      const ieDriver =
+    it('should download the file', async () => {
+      if (await checkConnectivity('update binary for windows test')) {
+        const ieDriver =
           new IEDriver({outDir: tmpDir, osType: 'Windows_NT', osArch: 'x64'});
       await ieDriver.updateBinary();
 
@@ -49,7 +53,7 @@ describe('iedriver', () => {
       const executableFile =
           path.resolve(tmpDir, 'IEDriverServer_' + versionObj.version + '.exe');
       expect(fs.statSync(executableFile).size).toBeTruthy();
-      done();
+      }
     });
   });
 });

--- a/lib/provider/selenium_server.spec-unit.ts
+++ b/lib/provider/selenium_server.spec-unit.ts
@@ -62,8 +62,10 @@ describe('selenium_server', () => {
       it('should use a selenium server with node options', () => {
         spyOn(fs, 'readFileSync').and.returnValue(configBinaries);
         const seleniumServer = new SeleniumServer();
+        seleniumServer.runAsDetach = true;
+        seleniumServer.runAsNode = true;
         const cmd = seleniumServer.getCmdStartServer(
-            {'-Dwebdriver.chrome.driver': 'path/to/chromedriver'}, null, true);
+            {'-Dwebdriver.chrome.driver': 'path/to/chromedriver'});
         expect(cmd.join(' '))
             .toContain(
                 '-Dwebdriver.chrome.driver=path/to/chromedriver ' +

--- a/lib/provider/utils/cloud_storage_xml.spec-int.ts
+++ b/lib/provider/utils/cloud_storage_xml.spec-int.ts
@@ -34,143 +34,143 @@ describe('cloud_storage_xml', () => {
   let proc: childProcess.ChildProcess;
   const origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
 
-  beforeAll((done) => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
-    proc = spawnProcess('node', ['dist/spec/server/http_server.js']);
-    log.debug('http-server: ' + proc.pid);
-    setTimeout(done, 3000);
+  beforeAll(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
   });
 
-  afterAll((done) => {
-    process.kill(proc.pid);
+  afterAll(() => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
-    setTimeout(done, 5000);
   });
 
-  describe('updateXml', () => {
-    const fileName = path.resolve(tmpDir, 'foo.xml');
-    const xmlUrl = httpBaseUrl + '/spec/support/files/foo.xml';
-
-    beforeAll(() => {
-      try {
-        fs.mkdirSync(tmpDir);
-      } catch (err) {
-      }
-      try {
-        fs.unlinkSync(fileName);
-      } catch (err) {
-      }
+  describe('with a http server', () => {
+    beforeAll(async () => {
+      proc = spawnProcess('node', ['dist/spec/server/http_server.js']);
+      log.debug('http-server: ' + proc.pid);
+      await new Promise((resolve, _) => {
+        setTimeout(resolve, 3000);
+      });
     });
-
-    afterAll(() => {
-      try {
-        fs.unlinkSync(fileName);
-        fs.rmdirSync(tmpDir);
-      } catch (err) {
-      }
+  
+    afterAll(async () => {
+      process.kill(proc.pid);
+      await new Promise((resolve, _) => {
+        setTimeout(resolve, 5000);
+      });
     });
-
-    it('should request and write the file if it does not exist', (done) => {
-      try {
-        fs.statSync(fileName);
-        done.fail('file should not exist.');
-      } catch (err) {
-        updateXml(xmlUrl, {fileName})
-            .then(xmlContent => {
-              expect(fs.statSync(fileName).size).toBeGreaterThan(0);
-              expect(xmlContent['ListBucketResult']['Contents'][0]['Key'][0])
-                  .toBe('2.0/foobar.zip');
-              done();
-            })
-            .catch(_ => {
-              done.fail('thrown error from update xml');
-            });
-      }
+  
+    describe('updateXml', () => {
+      const fileName = path.resolve(tmpDir, 'foo.xml');
+      const xmlUrl = httpBaseUrl + '/spec/support/files/foo.xml';
+  
+      beforeAll(() => {
+        try {
+          fs.mkdirSync(tmpDir);
+        } catch (_) {
+        }
+        try {
+          fs.unlinkSync(fileName);
+        } catch (_) {
+        }
+      });
+  
+      afterAll(() => {
+        try {
+          fs.unlinkSync(fileName);
+          fs.rmdirSync(tmpDir);
+        } catch (_) {
+        }
+      });
+      
+      it('should request and write the file if it does not exist', async () => {
+        try {
+          fs.statSync(fileName);
+          expect('file should not exist.').toBeFalsy();
+        } catch (_) {
+          try {
+            const xmlContent = await updateXml(xmlUrl, {fileName});
+            expect(fs.statSync(fileName).size).toBeGreaterThan(0);
+            expect(xmlContent['ListBucketResult']['Contents'][0]['Key'][0])
+                .toBe('2.0/foobar.zip');
+          } catch(_) {
+            expect('thrown error from update xml.').toBeFalsy();
+          }
+        }
+      });
+  
+      it('should request and write the file if it is expired', async () => {
+        const mtime = Date.now() - (60 * 60 * 1000) - 5000;
+        const initialStats = fs.statSync(fileName);
+  
+        // Maintain the fs.statSync method before being spyed on.
+        // Spy on the fs.statSync method and return fake values.
+        const fsStatSync = fs.statSync;
+        spyOn(fs, 'statSync').and.returnValue({size: 1000, mtime});
+  
+        try {
+          const xmlContent = await updateXml(xmlUrl, {fileName});
+          expect(fsStatSync(fileName).size).toBeGreaterThan(0);
+          expect(fsStatSync(fileName).size).not.toBe(1000);
+          expect(fsStatSync(fileName).mtime.getMilliseconds())
+              .toBeGreaterThan(initialStats.mtime.getMilliseconds());
+          expect(xmlContent['ListBucketResult']['Contents'][0]['Key'][0])
+              .toBe('2.0/foobar.zip');
+        } catch (_) {
+          expect('debugging required').toBeFalsy();
+        }
+      });
+  
+      it('should read the file when it is not expired', async () => {
+        const initialStats = fs.statSync(fileName);
+        const mtime = Date.now();
+  
+        // Maintain the fs.statSync method before being spyed on.
+        // Spy on the fs.statSync method and return fake values.
+        const fsStatSync = fs.statSync;
+        spyOn(fs, 'statSync').and.returnValue({size: 1000, mtime});
+  
+        try {
+          const xmlContent = await updateXml(xmlUrl, {fileName});    
+          expect(fsStatSync(fileName).size).toBe(initialStats.size);
+          expect(fsStatSync(fileName).mtime.getMilliseconds())
+              .toBe(initialStats.mtime.getMilliseconds());
+          expect(xmlContent['ListBucketResult']['Contents'][0]['Key'][0])
+              .toBe('2.0/foobar.zip');
+        } catch (_) {
+          expect('debugging required').toBeFalsy();
+        }
+      });
     });
-
-    it('should request and write the file if it is expired', (done) => {
-      const mtime = Date.now() - (60 * 60 * 1000) - 5000;
-      const initialStats = fs.statSync(fileName);
-
-      // Maintain the fs.statSync method before being spyed on.
-      // Spy on the fs.statSync method and return fake values.
-      const fsStatSync = fs.statSync;
-      spyOn(fs, 'statSync').and.returnValue({size: 1000, mtime});
-
-      try {
-        updateXml(xmlUrl, {fileName})
-            .then(xmlContent => {
-              expect(fsStatSync(fileName).size).toBeGreaterThan(0);
-              expect(fsStatSync(fileName).size).not.toBe(1000);
-              expect(fsStatSync(fileName).mtime.getMilliseconds())
-                  .toBeGreaterThan(initialStats.mtime.getMilliseconds());
-              expect(xmlContent['ListBucketResult']['Contents'][0]['Key'][0])
-                  .toBe('2.0/foobar.zip');
-              done();
-            })
-            .catch(_ => {
-              done.fail('thrown error from update xml');
-            });
-      } catch (err) {
-        done.fail('debugging required');
-      }
-    });
-
-    it('should read the file when it is not expired', (done) => {
-      const initialStats = fs.statSync(fileName);
-      const mtime = Date.now();
-
-      // Maintain the fs.statSync method before being spyed on.
-      // Spy on the fs.statSync method and return fake values.
-      const fsStatSync = fs.statSync;
-      spyOn(fs, 'statSync').and.returnValue({size: 1000, mtime});
-
-      try {
-        updateXml(xmlUrl, {fileName})
-            .then(xmlContent => {
-              expect(fsStatSync(fileName).size).toBe(initialStats.size);
-              expect(fsStatSync(fileName).mtime.getMilliseconds())
-                  .toBe(initialStats.mtime.getMilliseconds());
-              expect(xmlContent['ListBucketResult']['Contents'][0]['Key'][0])
-                  .toBe('2.0/foobar.zip');
-              done();
-            })
-            .catch(err => {
-              done.fail('thrown error from update xml');
-            });
-      } catch (err) {
-        done.fail('debugging required');
-      }
+  
+    describe('convertXmlToVersionList', () => {
+      const fileName = 'spec/support/files/chromedriver.xml';
+  
+      it('should convert an xml file an object from the xml file', () => {
+        const versionList = convertXmlToVersionList(
+            fileName, '.zip', chromedriverVersionParser,
+            chromedriverSemanticVersionParser);
+        expect(Object.keys(versionList).length).toBe(3);
+        expect(versionList['2.0.0']).toBeTruthy();
+        expect(versionList['2.10.0']).toBeTruthy();
+        expect(versionList['2.20.0']).toBeTruthy();
+        expect(Object.keys(versionList['2.0.0']).length).toBe(4);
+        expect(Object.keys(versionList['2.10.0']).length).toBe(4);
+        expect(Object.keys(versionList['2.20.0']).length).toBe(4);
+        expect(versionList['2.0.0']['chromedriver_linux32.zip']['size'])
+            .toBe(7262134);
+        expect(versionList['2.10.0']['chromedriver_linux32.zip']['size'])
+            .toBe(2439424);
+        expect(versionList['2.20.0']['chromedriver_linux32.zip']['size'])
+            .toBe(2612186);
+      });
+  
+      it('should return a null value if the file does not exist', () => {
+        const versionList = convertXmlToVersionList(
+            'spec/support/files/does_not_exist.xml', '.zip',
+            chromedriverVersionParser, chromedriverSemanticVersionParser);
+        expect(versionList).toBeNull();
+      });
     });
   });
 
-  describe('convertXmlToVersionList', () => {
-    const fileName = 'spec/support/files/chromedriver.xml';
 
-    it('should convert an xml file an object from the xml file', () => {
-      const versionList = convertXmlToVersionList(
-          fileName, '.zip', chromedriverVersionParser,
-          chromedriverSemanticVersionParser);
-      expect(Object.keys(versionList).length).toBe(3);
-      expect(versionList['2.0.0']).toBeTruthy();
-      expect(versionList['2.10.0']).toBeTruthy();
-      expect(versionList['2.20.0']).toBeTruthy();
-      expect(Object.keys(versionList['2.0.0']).length).toBe(4);
-      expect(Object.keys(versionList['2.10.0']).length).toBe(4);
-      expect(Object.keys(versionList['2.20.0']).length).toBe(4);
-      expect(versionList['2.0.0']['chromedriver_linux32.zip']['size'])
-          .toBe(7262134);
-      expect(versionList['2.10.0']['chromedriver_linux32.zip']['size'])
-          .toBe(2439424);
-      expect(versionList['2.20.0']['chromedriver_linux32.zip']['size'])
-          .toBe(2612186);
-    });
-
-    it('should return a null value if the file does not exist', () => {
-      const versionList = convertXmlToVersionList(
-          'spec/support/files/does_not_exist.xml', '.zip',
-          chromedriverVersionParser, chromedriverSemanticVersionParser);
-      expect(versionList).toBeNull();
-    });
-  });
 });

--- a/lib/provider/utils/file_utils.spec-int.ts
+++ b/lib/provider/utils/file_utils.spec-int.ts
@@ -20,13 +20,12 @@ describe('file_utils', () => {
       expect(fileList[0]).toBe('bar');
     });
 
-    it('should return an error if the file does not exist', async (done) => {
+    it('should return an error if the file does not exist', async () => {
       try {
         await tarFileList('file_does_not_exist');
-        done.fail();
+        expect(false).toBeTruthy();
       } catch (err) {
         expect(err).toBeTruthy();
-        done();
       }
     });
   });
@@ -64,13 +63,12 @@ describe('file_utils', () => {
       expect(fileList[0]).toBe('bar');
     });
 
-    it('should return an error if the file does not exist', (done) => {
+    it('should return an error if the file does not exist', () => {
       try {
         zipFileList('file_does_not_exist');
-        done.fail();
+        expect(false).toBeTruthy();
       } catch (err) {
         expect(err).toBeTruthy();
-        done();
       }
     });
   });

--- a/lib/provider/utils/github_json.spec-int.ts
+++ b/lib/provider/utils/github_json.spec-int.ts
@@ -6,16 +6,14 @@ const fileName = path.resolve('spec/support/files/gecko.json');
 
 describe('github_json', () => {
   describe('requestRateLimit', () => {
-    it('should get rate limit assuming quota exists', async (done) => {
-      if (!await checkConnectivity('rate limit test')) {
-        done();
+    it('should get rate limit assuming quota exists', async () => {
+      if (await checkConnectivity('rate limit test')) {
+        const rateLimit = await requestRateLimit();
+        expect(rateLimit).toBeTruthy();
+        const rateLimitObj = JSON.parse(rateLimit);
+        expect(rateLimitObj['resources']).toBeTruthy();
+        expect(rateLimitObj['resources']['core']).toBeTruthy();
       }
-      const rateLimit = await requestRateLimit();
-      expect(rateLimit).toBeTruthy();
-      const rateLimitObj = JSON.parse(rateLimit);
-      expect(rateLimitObj['resources']).toBeTruthy();
-      expect(rateLimitObj['resources']['core']).toBeTruthy();
-      done();
     });
   });
 

--- a/lib/provider/utils/http_utils.spec-int.ts
+++ b/lib/provider/utils/http_utils.spec-int.ts
@@ -19,86 +19,98 @@ const fooArrayUrl = httpBaseUrl + '/spec/support/files/foo_array.json';
 const fooXmlUrl = httpBaseUrl + '/spec/support/files/foo.xml';
 const barZipSize = 171;
 
-describe('binary_utils', () => {
+describe('http_utils', () => {
   const origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
   let proc: childProcess.ChildProcess;
 
-  beforeAll((done) => {
+  beforeAll(() => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
-    proc = spawnProcess('node', ['dist/spec/server/http_server.js']);
-    log.debug('http-server: ' + proc.pid);
-    setTimeout(done, 3000);
-
-    try {
-      fs.mkdirSync(tmpDir);
-    } catch (err) {
-    }
-    try {
-      fs.unlinkSync(fileName);
-    } catch (err) {
-    }
   });
 
-  afterAll((done) => {
-    try {
-      fs.unlinkSync(fileName);
-      fs.rmdirSync(tmpDir);
-    } catch (err) {
-    }
-
-    process.kill(proc.pid);
+  afterAll(() => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
-    setTimeout(done, 5000);
   });
 
-  describe('requestBinary', () => {
-    it('should download the file if no file exists or ' +
-           'the content lenght is different',
-       (done) => {
-         requestBinary(binaryUrl, {fileName, fileSize: 0})
-             .then((result) => {
-               expect(result).toBeTruthy();
-               expect(fs.statSync(fileName).size).toBe(barZipSize);
-               done();
-             })
-             .catch(err => {
-               done.fail(err);
-             });
-       });
-
-    it('should not download the file if the file exists', (done) => {
-      requestBinary(binaryUrl, {fileName, fileSize: barZipSize})
-          .then((result) => {
-            expect(result).toBeFalsy();
-            expect(fs.statSync(fileName).size).toBe(barZipSize);
-            done();
-          })
-          .catch(err => {
-            done.fail(err);
-          });
+  describe('with a http server', () => {
+    beforeAll(async () => {
+      proc = spawnProcess('node', ['dist/spec/server/http_server.js']);
+      log.debug('http-server: ' + proc.pid);
+      await new Promise((resolve, _) => {
+        setTimeout(resolve, 3000);
+      });
+  
+      try {
+        fs.mkdirSync(tmpDir);
+      } catch (err) {
+      }
+      try {
+        fs.unlinkSync(fileName);
+      } catch (err) {
+      }
     });
-  });
-
-  describe('requestBody', () => {
-    it('should download a json object file', async () => {
-      const foo = await requestBody(fooJsonUrl, {});
-      const fooJson = JSON.parse(foo);
-      expect(fooJson['foo']).toBe('abc');
-      expect(fooJson['bar']).toBe(123);
+  
+    afterAll(async () => {
+      try {
+        fs.unlinkSync(fileName);
+        fs.rmdirSync(tmpDir);
+      } catch (err) {
+      }
+  
+      process.kill(proc.pid);
+      await new Promise((resolve, _) => {
+        setTimeout(resolve, 3000);
+      });
     });
 
-    it('should download a json array file', async () => {
-      const foo = await requestBody(fooArrayUrl, {});
-      const fooJson = JSON.parse(foo);
-      expect(fooJson.length).toBe(3);
-      expect(fooJson[0]['foo']).toBe('abc');
-      expect(fooJson[1]['foo']).toBe('def');
-      expect(fooJson[2]['foo']).toBe('ghi');
+    describe('requestBinary', () => {
+      it('should download the file if no file exists or ' +
+             'the content lenght is different',
+         (done) => {
+           requestBinary(binaryUrl, {fileName, fileSize: 0})
+               .then((result) => {
+                 expect(result).toBeTruthy();
+                 expect(fs.statSync(fileName).size).toBe(barZipSize);
+                 done();
+               })
+               .catch(err => {
+                 done.fail(err);
+               });
+         });
+  
+      it('should not download the file if the file exists', (done) => {
+        requestBinary(binaryUrl, {fileName, fileSize: barZipSize})
+            .then((result) => {
+              expect(result).toBeFalsy();
+              expect(fs.statSync(fileName).size).toBe(barZipSize);
+              done();
+            })
+            .catch(err => {
+              done.fail(err);
+            });
+      });
     });
-
-    it('should get the xml file', async () => {
-      const text = await requestBody(fooXmlUrl, {});
-      expect(text.length).toBeGreaterThan(0);
+  
+    describe('requestBody', () => {
+      it('should download a json object file', async () => {
+        const foo = await requestBody(fooJsonUrl, {});
+        const fooJson = JSON.parse(foo);
+        expect(fooJson['foo']).toBe('abc');
+        expect(fooJson['bar']).toBe(123);
+      });
+  
+      it('should download a json array file', async () => {
+        const foo = await requestBody(fooArrayUrl, {});
+        const fooJson = JSON.parse(foo);
+        expect(fooJson.length).toBe(3);
+        expect(fooJson[0]['foo']).toBe('abc');
+        expect(fooJson[1]['foo']).toBe('def');
+        expect(fooJson[2]['foo']).toBe('ghi');
+      });
+  
+      it('should get the xml file', async () => {
+        const text = await requestBody(fooXmlUrl, {});
+        expect(text.length).toBeGreaterThan(0);
+      });
     });
   });
 });

--- a/spec/server/proxy_server.ts
+++ b/spec/server/proxy_server.ts
@@ -1,11 +1,13 @@
 import * as http from 'http';
 import * as httpProxy from 'http-proxy';
-
+import * as loglevel from 'loglevel';
 import * as env from './env';
+
+const log = loglevel.getLogger('webdriver-manager-test');
 
 const proxy = http.createServer((request, response) => {
   let hostHeader = request.headers['host'];
-  console.log(
+  log.debug(
       'request made to proxy: ' + request.url + ', ' +
       'target: ' + hostHeader);
   if (hostHeader.startsWith('http://') || hostHeader.startsWith('127.0.0.1')) {


### PR DESCRIPTION
- Breaking change: update the options object. Remove the initOptions and
Providers enum.
- Add port number to options object.
- Remove extra options passed to starting the server.
- Use the port number from the options to start and stop the server.

closes #81