### PR TITLE
fix: fix extracting geckodriver when used from Electron app

### DIFF
--- a/lib/provider/utils/file_utils.ts
+++ b/lib/provider/utils/file_utils.ts
@@ -123,7 +123,7 @@ export async function tarFileList(tarball: string): Promise<string[]> {
         onentry: entry => {
           fileList.push(entry['path'].toString());
         }
-      });    
+      });
   return fileList;
 }
 
@@ -141,15 +141,8 @@ export async function uncompressTarball(
   }
 
   const fileList = await tarFileList(tarball);
-  return tar.extract({file: tarball}).then(() => {
-    const dstFiles: string[] = [];
-    for (const fileItem of fileList) {
-      const dstFileName = path.resolve(dstDir, fileItem);
-      fs.renameSync(path.resolve(fileItem), dstFileName);
-      dstFiles.push(dstFileName);
-    }
-    return dstFiles;
-  });
+  tar.extract({file: tarball, sync: true, cwd: dstDir});
+  return fileList.map((fileName) => path.resolve(dstDir, fileName));
 }
 
 /**


### PR DESCRIPTION
In case `update` is used from Electron app on Mac, `tar.extract` tries to use the dir inside packed app for extraction by default and fails silently; then `GeckoDriver.updateBinary` never resolves. 

This fix tells `tar.extract` to unpack to destination dir which needs to be outside of app package dir in case of Electron client.