### PR TITLE
feat: add a callback for `start` sending Selenium pid to client app

### DIFF
--- a/lib/cmds/start.ts
+++ b/lib/cmds/start.ts
@@ -36,20 +36,22 @@ export async function handler(argv: yargs.Arguments) {
  * Goes through all the option providers and creates a set of java options
  * to pass to java when starting the selenium server standalone.
  * @param options The constructed options.
+ * @param callback Function to get called when Selenium is started
  * @returns Promise starting the server with the resolved exit code.
  */
-export function start(options: Options): Promise<number> {
+export function start(options: Options, callback?: (pid: number) => void): Promise<number> {
   const optionsBinary = addOptionsBinary(options);
-  return startBinary(optionsBinary);
+  return startBinary(optionsBinary, callback);
 }
 
 /**
  * Goes through all the option providers and creates a set of java options
  * to pass to java when starting the selenium server standalone.
  * @param optionsBinary The constructed options with binaries.
+ * @param callback Function to get called when Selenium is started
  * @returns Promise starting the server with the resolved exit code.
  */
-export function startBinary(optionsBinary: OptionsBinary): Promise<number> {
+export function startBinary(optionsBinary: OptionsBinary, callback?: (pid: number) => void): Promise<number> {
   if (optionsBinary.server && optionsBinary.server.binary) {
     const seleniumServer = (optionsBinary.server.binary as SeleniumServer);
     if (optionsBinary.server.chromeLogs) {
@@ -73,7 +75,7 @@ export function startBinary(optionsBinary: OptionsBinary): Promise<number> {
       }
     }
     return seleniumServer.startServer(seleniumServer.javaOpts,
-      optionsBinary.server.version);
+      optionsBinary.server.version, callback);
   }
   return Promise.reject('Could not start the server');
 }

--- a/lib/provider/selenium_server.ts
+++ b/lib/provider/selenium_server.ts
@@ -10,6 +10,7 @@ import {convertXmlToVersionList, updateXml} from './utils/cloud_storage_xml';
 import {generateConfigFile, getBinaryPathFromConfig, removeFiles,} from './utils/file_utils';
 import {curlCommand, initOptions, requestBinary} from './utils/http_utils';
 import {getVersion} from './utils/version_list';
+import {Options} from "..";
 
 const log = loglevel.getLogger('webdriver-manager');
 
@@ -112,9 +113,10 @@ export class SeleniumServer extends ProviderClass implements ProviderInterface {
    * Starts selenium standalone server and handles emitted exit events.
    * @param opts The options to pass to the jar file.
    * @param version The optional version of the selenium jar file.
+   * @param callback Function to get called when Selenium is started
    * @returns A promise so the server can run while awaiting its completion.
    */
-  startServer(opts: {[key: string]: string}, version?: string):
+  startServer(opts: {[key: string]: string}, version?: string, callback?: (pid: number) => void):
       Promise<number> {
     const java = this.getJava();
     return new Promise<number>(async (resolve, _) => {
@@ -139,6 +141,7 @@ export class SeleniumServer extends ProviderClass implements ProviderInterface {
         this.seleniumProcess =
             childProcess.spawn(java, cmd, {stdio: 'inherit'});
         log.info(`selenium process id: ${this.seleniumProcess.pid}`);
+        callback(this.seleniumProcess.pid);
 
         this.seleniumProcess.on('exit', (code: number) => {
           log.info(`Selenium Standalone has exited with code: ${code}`);


### PR DESCRIPTION
If the client project is Mac packaged Electron app the Selenium process doesn't exit automatically on host process exit (even in "attached" mode) - then this callback will allow the host app to kill it manually.